### PR TITLE
Trips, tab restructure, data fixes

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -37,3 +37,23 @@ jobs:
           name: pytest-coverage-html-${{ matrix.python-version }}
           path: htmlcov/
         if: ${{ always() }}
+
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: make setup
+      - name: Install Playwright browsers
+        run: uv run playwright install --with-deps chromium
+      - name: Run e2e tests
+        run: make test-e2e
+      - name: Upload e2e results
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-results
+          path: junit/e2e-results.xml
+        if: ${{ always() }}

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ test:
 
 .PHONY: test-e2e
 test-e2e:
-	uv run pytest tests/e2e -v
+	uv run pytest tests/e2e -v --junitxml=junit/e2e-results.xml
 
 .PHONY: test-all
 test-all:

--- a/README.md
+++ b/README.md
@@ -17,14 +17,44 @@ categorized expenses, budget tracking, and a fully interactive web dashboard.
   sub-description.
 - **Interactive web dashboard** — local server with drag-and-drop import, inline
   categorization, anomaly detection, budget vs actual charts, category rule
-  management, recycle bin. Zero external dependencies (stdlib `http.server`).
+  management, recycle bin, trips. Zero external dependencies (stdlib
+  `http.server`).
 - **Static HTML export** — self-contained Chart.js dark-theme dashboard for
   sharing/archiving.
 - **Anomaly detection** — flags transactions exceeding 2x their category
   average.
 - **Budget tracking** — set monthly budgets per category, copy between months,
   budget vs actual visualization.
+- **Trips** — tag a date range as a trip, auto-assign expenses, split costs
+  with a partner (configurable %), mark individual transactions as "just me".
+- **Reimbursements** — link income transactions to the expenses they offset
+  (e.g. Canada Life covering a wellness charge).
 - **Soft delete** — recycle bin with restore.
+
+## Quickstart (fresh install)
+
+```bash
+# 1. Install uv (https://docs.astral.sh/uv/)
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# 2. Clone and set up
+git clone https://github.com/cboin1996/show-me-the-money ~/proj/show-me-the-money
+cd ~/proj/show-me-the-money
+make setup
+
+# 3. Drop your bank CSVs in data/csv/
+mkdir -p data/csv
+cp ~/Downloads/*.csv data/csv/
+
+# 4. Import
+smtm import
+
+# 5. Open the dashboard
+smtm serve
+```
+
+Browser opens at `http://127.0.0.1:8000`. From there: categorize merchants,
+set budgets, review anomalies — no further CLI required.
 
 ## Setup
 
@@ -34,75 +64,125 @@ Requires [uv](https://docs.astral.sh/uv/):
 make setup
 ```
 
-## Usage
-
-### Interactive Dashboard
+## Web Dashboard
 
 ```bash
 smtm serve                     # http://127.0.0.1:8000
 smtm serve --port 9000         # custom port
+smtm serve --reload            # auto-reload on source changes (dev mode)
 ```
 
-Opens a browser with the full dashboard. Tabs:
+### Tabs
 
-- **Overview** — monthly expense stacked bar, category donut, trend lines,
-  income vs expenses, summary cards. Anomalies panel flags transactions
-  exceeding 2x their category average (e.g. "$3,511 at Canadian Tire — 27.9x
-  your usual Shopping spend").
-- **Import** — drag-and-drop CSV files onto the upload zone. Preview shows
-  parsed count, date range, and classification breakdown before confirming.
-  Import history table below.
-- **Categorize** — uncategorized merchants grouped by store name with
-  transaction count and total spend. Pick a category from the dropdown to
-  classify all matching transactions at once. Keyword suggestions section offers
-  bulk auto-categorization based on store name patterns.
-- **Budgets** — budget vs actual grouped bar chart per category. Set/edit
-  monthly budgets inline. Copy budgets between months.
-- **Manage** — category rules table (add/view pattern→category mappings), store
-  pairs table (raw→normalized name mappings), recycle bin (restore soft-deleted
-  transactions).
+| Tab | What's here |
+|-----|-------------|
+| **Overview** | Monthly stacked bar, category donut, trend lines, income vs expenses, summary cards, anomalies |
+| **Transactions** | Full transaction table — search, filter by category/date, bulk assign, bulk delete, inline category edit, export CSV |
+| **Organize** | Recategorize uncategorized merchants, category rules, store pairs (raw→normalized), recycle bin |
+| **Budgets** | Budget vs actual chart, set/edit monthly budgets, copy between months |
+| **Reimburse** | Known reimbursers, link income to the expense it covers, pending unlinked reimbursements |
+| **Trips** | Tag a date range as a trip, auto-assign expenses, configurable partner split %, per-transaction "just me" flag |
+| **Analytics** | Spend velocity, day-of-week chart, top merchants, month-over-month table, recurring charges, z-score outliers |
+| **Import** | Drag-and-drop CSV upload, preview before confirming, import history |
 
-All mutations (import, categorize, delete, budget set) happen via the REST API
-and refresh the UI live.
+### Key workflows
 
-### CLI
+**Import new transactions**
+
+Drag CSVs onto the Import tab → preview shows parsed count and classification
+breakdown → Confirm Import.
+
+**Categorize uncategorized merchants**
+
+Organize tab → uncategorized section groups merchants by store name with total
+spend. Select category → all matching transactions categorized at once.
+
+**Set a budget**
+
+Budgets tab → enter month (YYYY-MM), pick category, enter amount → Save.
+
+**Track a trip**
+
+Trips tab → enter name, start/end dates, check which categories to exclude
+from totals (Investments excluded by default) → Create & Auto-assign.
+
+In trip detail: set split % (e.g. 60% you / 40% partner). For transactions
+entirely yours (not shared), click **Just me** — they count 100% toward your
+share regardless of split %.
+
+**Link a reimbursement**
+
+Reimburse tab → add a reimburser pattern (e.g. `canada life`, substring match).
+Matching income transactions appear in Pending — link each to the expense it
+covers.
+
+## CLI
 
 ```bash
-# Import CSVs (auto-detects bank format)
-smtm import --csv-dir data/new
+# Import CSVs from data/csv/ (auto-detects bank format)
+smtm import
+
+# Import from a specific directory
+smtm import --csv-dir ~/Downloads/statements
 
 # Preview without importing
-smtm profile --csv-dir data/new
+smtm profile
+smtm profile --csv-dir ~/Downloads/statements
 
 # Suggest categories for unclassified transactions
 smtm suggest
-smtm suggest --apply
+smtm suggest --apply           # auto-apply all suggestions
 
 # Generate reports
-smtm report              # text summary
-smtm report --html       # static HTML dashboard
+smtm report                    # text summary to stdout
+smtm report --html             # static HTML dashboard → data/report.html
+smtm report --pdf              # PDF report → data/report.pdf
 
 # Budget management
 smtm budget set 2026-01 Dining=600 Groceries=400
 smtm budget copy 2026-01 2026-02
 smtm budget show
+smtm budget show 2026-01
+
+# Store name management
+smtm stores list
+smtm stores discover           # suggest raw→normalized pairs
+smtm stores discover --apply
+smtm stores dupes              # find duplicate normalized names
 
 # Import history
 smtm history
 
-# Soft-delete transactions
+# Soft-delete / restore transactions (UUIDs visible in dashboard)
 smtm delete <uuid>
+smtm delete <uuid> --restore
+
+# Reimburse
+smtm reimburse add <pattern>
+smtm reimburse list
+smtm reimburse pending
+smtm reimburse link <income-uuid> <expense-uuid>
 ```
+
+Global flags (before the subcommand):
+
+```bash
+smtm --db-path /path/to/smtm.db --csv-dir /path/to/csvs <subcommand>
+```
+
+Defaults: `--db-path data/smtm.db`, `--csv-dir data/csv`.
 
 ## Development
 
 ```bash
-make setup         # uv sync --extra dev
-make lint          # format with black + isort
-make lint-check    # check formatting (CI)
-make test          # pytest with coverage
-make test-stdout   # pytest without XML artifacts
-make upgrade       # uv lock --upgrade
+make setup          # uv sync --extra dev + playwright install
+make lint           # format with black + isort
+make lint-check     # check formatting (CI)
+make test           # pytest unit + integration tests with coverage
+make test-e2e       # playwright e2e browser tests
+make test-all       # unit + e2e together
+make test-stdout    # unit tests without XML artifacts
+make upgrade        # uv lock --upgrade
 ```
 
 ## Adding a New Bank
@@ -128,3 +208,19 @@ class YourBankAdapter(BaseAdapter):
 ```
 
 Register it in `smtm/adapters/__init__.py`.
+
+## Schema migrations
+
+Migrations are numbered entries in `smtm/db.py::_MIGRATIONS`. To add a column:
+
+```python
+_MIGRATIONS = [
+    ...existing entries...,
+    # N: description
+    "ALTER TABLE some_table ADD COLUMN new_col TEXT DEFAULT ''",
+]
+SCHEMA_VERSION = N
+```
+
+`schema_version` tracks which migrations have run. `db.initialize()` applies
+pending ones on startup — safe to run multiple times.

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ categorized expenses, budget tracking, and a fully interactive web dashboard.
   average.
 - **Budget tracking** — set monthly budgets per category, copy between months,
   budget vs actual visualization.
-- **Trips** — tag a date range as a trip, auto-assign expenses, split costs
-  with a partner (configurable %), mark individual transactions as "just me".
+- **Trips** — tag a date range as a trip, auto-assign expenses, split costs with
+  a partner (configurable %), mark individual transactions as "just me".
 - **Reimbursements** — link income transactions to the expenses they offset
   (e.g. Canada Life covering a wellness charge).
 - **Soft delete** — recycle bin with restore.
@@ -53,8 +53,8 @@ smtm import
 smtm serve
 ```
 
-Browser opens at `http://127.0.0.1:8000`. From there: categorize merchants,
-set budgets, review anomalies — no further CLI required.
+Browser opens at `http://127.0.0.1:8000`. From there: categorize merchants, set
+budgets, review anomalies — no further CLI required.
 
 ## Setup
 
@@ -74,16 +74,16 @@ smtm serve --reload            # auto-reload on source changes (dev mode)
 
 ### Tabs
 
-| Tab | What's here |
-|-----|-------------|
-| **Overview** | Monthly stacked bar, category donut, trend lines, income vs expenses, summary cards, anomalies |
+| Tab              | What's here                                                                                                          |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------- |
+| **Overview**     | Monthly stacked bar, category donut, trend lines, income vs expenses, summary cards, anomalies                       |
 | **Transactions** | Full transaction table — search, filter by category/date, bulk assign, bulk delete, inline category edit, export CSV |
-| **Organize** | Recategorize uncategorized merchants, category rules, store pairs (raw→normalized), recycle bin |
-| **Budgets** | Budget vs actual chart, set/edit monthly budgets, copy between months |
-| **Reimburse** | Known reimbursers, link income to the expense it covers, pending unlinked reimbursements |
-| **Trips** | Tag a date range as a trip, auto-assign expenses, configurable partner split %, per-transaction "just me" flag |
-| **Analytics** | Spend velocity, day-of-week chart, top merchants, month-over-month table, recurring charges, z-score outliers |
-| **Import** | Drag-and-drop CSV upload, preview before confirming, import history |
+| **Organize**     | Recategorize uncategorized merchants, category rules, store pairs (raw→normalized), recycle bin                      |
+| **Budgets**      | Budget vs actual chart, set/edit monthly budgets, copy between months                                                |
+| **Reimburse**    | Known reimbursers, link income to the expense it covers, pending unlinked reimbursements                             |
+| **Trips**        | Tag a date range as a trip, auto-assign expenses, configurable partner split %, per-transaction "just me" flag       |
+| **Analytics**    | Spend velocity, day-of-week chart, top merchants, month-over-month table, recurring charges, z-score outliers        |
+| **Import**       | Drag-and-drop CSV upload, preview before confirming, import history                                                  |
 
 ### Key workflows
 
@@ -103,8 +103,8 @@ Budgets tab → enter month (YYYY-MM), pick category, enter amount → Save.
 
 **Track a trip**
 
-Trips tab → enter name, start/end dates, check which categories to exclude
-from totals (Investments excluded by default) → Create & Auto-assign.
+Trips tab → enter name, start/end dates, check which categories to exclude from
+totals (Investments excluded by default) → Create & Auto-assign.
 
 In trip detail: set split % (e.g. 60% you / 40% partner). For transactions
 entirely yours (not shared), click **Just me** — they count 100% toward your

--- a/smtm/dashboard.py
+++ b/smtm/dashboard.py
@@ -516,6 +516,7 @@ body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sa
 .charts { display: grid; grid-template-columns: 2fr 1fr; gap: 20px; margin-bottom: 30px; }
 .chart-box { background: #1e293b; border-radius: 12px; padding: 20px; }
 .chart-box h2 { font-size: 16px; margin-bottom: 12px; color: #f8fafc; }
+.chart-box canvas { max-height: 280px; }
 .trend-row { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; margin-bottom: 30px; }
 .section { background: #1e293b; border-radius: 12px; padding: 20px; margin-bottom: 20px; }
 .section h2 { font-size: 16px; margin-bottom: 12px; color: #f8fafc; }
@@ -661,11 +662,13 @@ input[type="checkbox"] { accent-color: #3b82f6; width: 14px; height: 14px; curso
     </div>
     <div class="section">
         <h2>Category Rules <span id="rulesCount" style="font-size:12px;color:#94a3b8"></span></h2>
+        <p class="subtitle">Rules map store names to categories. <strong>Editing a transaction category also saves a rule</strong> so future imports self-categorize.</p>
         <div class="form-row">
             <input type="text" id="newRulePattern" placeholder="Pattern (store name)" list="dl-expense-stores">
             <select id="newRuleCat"></select>
             <select id="newRuleType"><option value="exact">exact</option><option value="substring">substring</option></select>
             <button class="btn" id="addRuleBtn">Add Rule</button>
+            <button class="btn btn-outline btn-sm" id="normalizeRulesBtn" title="Update any rules using raw bank names to use normalized store names instead">Normalize rule patterns</button>
         </div>
         <div class="form-row">
             <input type="text" id="rulesSearch" placeholder="Search rules..." style="width:250px">
@@ -1811,7 +1814,7 @@ const App = {
                 <td><input type="checkbox" data-uuid="${t.uuid}" ${checked} onchange="App.toggleSelect('${t.uuid}', this.checked)"></td>
                 <td>${t.date}</td>
                 <td title="${t.store_raw}">${t.store_normalized}</td>
-                <td>${catBadge(t.category)} <select class="inline-cat-select" onchange="App.inlineCategory('${t.uuid}', this.value)"><option value="">edit</option>${catOpts}</select></td>
+                <td>${catBadge(t.category)} <select class="inline-cat-select" onchange="App.inlineCategory('${t.uuid}', '${(t.store_normalized||t.store_raw).replace(/'/g,"\\'")}', this.value)"><option value="">edit</option>${catOpts}</select></td>
                 <td style="text-align:right;font-variant-numeric:tabular-nums">${t.type==='income'?'+':'-'}${amtDisplay}</td>
                 <td>${t.type}</td>
                 <td>${tripNames}</td>
@@ -1867,10 +1870,13 @@ const App = {
         await this.refresh();
     },
 
-    async inlineCategory(uuid, category) {
+    async inlineCategory(uuid, store, category) {
         if (!category) return;
         await api(`/api/transactions/${uuid}/category`, {method:'PATCH', headers:{'Content-Type':'application/json'}, body:JSON.stringify({category})});
-        toast(`Updated category to ${category}`);
+        if (store) {
+            await apiPost('/api/rules', {pattern: store, category, match_type: 'exact'});
+        }
+        toast(`${store || uuid} → ${category} (rule saved)`);
         await this.refresh();
     },
 
@@ -1952,6 +1958,12 @@ document.getElementById('addRuleBtn').addEventListener('click', async () => {
     const data = await apiPost('/api/rules', {pattern, category: cat, match_type: type});
     toast(`Rule added: ${pattern} → ${cat} (${data.updated || 0} transactions updated)`);
     document.getElementById('newRulePattern').value = '';
+    await App.refresh();
+});
+
+document.getElementById('normalizeRulesBtn').addEventListener('click', async () => {
+    const data = await apiPost('/api/rules/normalize', {});
+    toast(`Normalized ${data.normalized} rule pattern${data.normalized === 1 ? '' : 's'}`);
     await App.refresh();
 });
 

--- a/smtm/dashboard.py
+++ b/smtm/dashboard.py
@@ -586,11 +586,13 @@ input[type="checkbox"] { accent-color: #3b82f6; width: 14px; height: 14px; curso
 
 <div class="tab-bar" id="mainTabs" data-testid="tab-bar">
     <div class="tab active" data-tab="overview" data-testid="tab-overview">Overview</div>
+    <div class="tab" data-tab="transactions" data-testid="tab-transactions">Transactions</div>
+    <div class="tab" data-tab="organize" data-testid="tab-organize">Organize</div>
+    <div class="tab" data-tab="budgets" data-testid="tab-budgets">Budgets</div>
+    <div class="tab" data-tab="reimburse" data-testid="tab-reimburse">Reimburse</div>
+    <div class="tab" data-tab="trips" data-testid="tab-trips">Trips</div>
     <div class="tab" data-tab="analytics" data-testid="tab-analytics">Analytics</div>
     <div class="tab" data-tab="import" data-testid="tab-import">Import</div>
-    <div class="tab" data-tab="categorize" data-testid="tab-categorize">Categorize</div>
-    <div class="tab" data-tab="budgets" data-testid="tab-budgets">Budgets</div>
-    <div class="tab" data-tab="manage" data-testid="tab-manage">Manage</div>
 </div>
 
 <!-- OVERVIEW TAB -->
@@ -607,6 +609,189 @@ input[type="checkbox"] { accent-color: #3b82f6; width: 14px; height: 14px; curso
         <h2>Anomalies <span style="font-size:12px;color:#fbbf24">(transactions &gt; 2x category average)</span></h2>
         <input type="text" id="anomalySearch" placeholder="Search by store or category..." style="width:250px;margin-bottom:12px;background:#0f172a;border:1px solid #334155;color:#f8fafc;padding:6px 12px;border-radius:6px;font-size:13px">
         <div id="anomaliesList"></div>
+    </div>
+</div>
+
+<!-- TRANSACTIONS TAB -->
+<div id="tab-transactions" class="hidden">
+    <div class="filters">
+        <div><label>Search</label><br><input type="text" id="searchInput" placeholder="Store, category..."></div>
+        <div><label>Category</label><br><select id="categoryFilter"><option value="">All</option></select></div>
+        <div><label>Month</label><br><select id="monthFilter"><option value="">All</option></select></div>
+        <div><label>Type</label><br><select id="typeFilter"><option value="">All</option><option value="expense">Expenses</option><option value="income">Income</option></select></div>
+        <div><label>From</label><br><input type="date" id="dateFrom" style="width:130px"></div>
+        <div><label>To</label><br><input type="date" id="dateTo" style="width:130px"></div>
+        <div><label>Min $</label><br><input type="number" id="minAmount" style="width:80px" step="0.01"></div>
+        <div><label>Max $</label><br><input type="number" id="maxAmount" style="width:80px" step="0.01"></div>
+        <div style="margin-left:auto;align-self:flex-end"><button class="btn btn-outline" id="exportCsvBtn" data-testid="export-csv-btn">Export CSV</button></div>
+    </div>
+    <div id="bulkBar" class="bulk-bar hidden" data-testid="bulk-bar">
+        <span><span class="count" id="bulkCount">0</span> selected</span>
+        <select id="bulkCatSelect" class="inline-cat-select"><option value="">Assign category...</option></select>
+        <button class="btn btn-sm btn-success" id="bulkCatBtn">Apply</button>
+        <button class="btn btn-sm btn-danger" id="bulkDeleteBtn">Delete Selected</button>
+        <button class="btn btn-sm btn-outline" id="bulkClearBtn">Clear</button>
+    </div>
+    <div class="table-wrap">
+        <div class="txn-count" id="txnCount"></div>
+        <div class="scroll-table">
+            <table id="txnTable" data-testid="txn-table">
+                <thead><tr><th><input type="checkbox" id="selectAll" data-testid="select-all"></th><th data-col="date">Date</th><th data-col="store">Store</th><th data-col="category">Category</th><th data-col="amount">Amount</th><th data-col="type">Type</th><th>Trip</th><th>Actions</th></tr></thead>
+                <tbody id="txnBody" data-testid="txn-body"></tbody>
+            </table>
+        </div>
+    </div>
+</div>
+
+<!-- ORGANIZE TAB (merged Categorize + Manage data hygiene) -->
+<div id="tab-organize" class="hidden">
+    <div class="section" style="display:flex;gap:12px;align-items:center;padding:16px 20px">
+        <button class="btn btn-success" id="recatAllBtn" data-testid="recategorize-btn">Re-categorize All Uncategorized</button>
+        <span id="recatResult" data-testid="recategorize-result" style="font-size:13px;color:#94a3b8"></span>
+    </div>
+    <div id="uncategorizedSection" class="section">
+        <h2>Uncategorized Merchants</h2>
+        <p class="subtitle">Select a category to auto-classify all transactions from that merchant</p>
+        <div class="scroll-table"><table><thead><tr><th>Store</th><th>Count</th><th>Total Spend</th><th>Category</th></tr></thead><tbody id="uncatBody"></tbody></table></div>
+    </div>
+    <div id="suggestSection" class="section">
+        <h2>Keyword Suggestions</h2>
+        <p class="subtitle">Auto-detected categories based on store name keywords</p>
+        <div style="margin-bottom:12px"><button class="btn btn-success" id="applyAllSuggBtn">Apply All</button></div>
+        <div class="scroll-table"><table><thead><tr><th>Store</th><th>Suggested</th><th>Amount</th><th>Count</th><th>Actions</th></tr></thead><tbody id="suggestBody"></tbody></table></div>
+    </div>
+    <div class="section">
+        <h2>Category Rules <span id="rulesCount" style="font-size:12px;color:#94a3b8"></span></h2>
+        <div class="form-row">
+            <input type="text" id="newRulePattern" placeholder="Pattern (store name)" list="dl-expense-stores">
+            <select id="newRuleCat"></select>
+            <select id="newRuleType"><option value="exact">exact</option><option value="substring">substring</option></select>
+            <button class="btn" id="addRuleBtn">Add Rule</button>
+        </div>
+        <div class="form-row">
+            <input type="text" id="rulesSearch" placeholder="Search rules..." style="width:250px">
+        </div>
+        <div class="scroll-table" style="max-height:300px"><table><thead><tr><th>Pattern</th><th>Category</th><th>Match Type</th></tr></thead><tbody id="rulesBody"></tbody></table></div>
+    </div>
+    <div class="section">
+        <h2>Store Pairs <span id="pairsCount" style="font-size:12px;color:#94a3b8"></span></h2>
+        <p class="subtitle">Map raw bank names to clean merchant names. Changes auto-propagate to all transactions.</p>
+        <div class="form-row">
+            <input type="text" id="newPairRaw" placeholder="Raw name" list="dl-expense-raw">
+            <input type="text" id="newPairNorm" placeholder="Normalized name" list="dl-all-stores">
+            <button class="btn" id="addPairBtn">Add Pair</button>
+        </div>
+        <div class="form-row">
+            <input type="text" id="pairsSearch" placeholder="Search pairs..." style="width:250px">
+        </div>
+        <div class="scroll-table" style="max-height:300px"><table><thead><tr><th>Raw Name</th><th>Normalized</th><th></th></tr></thead><tbody id="pairsBody"></tbody></table></div>
+        <h3 style="margin-top:16px;font-size:14px">Suggested Pairs <span id="suggestedPairsCount" style="font-size:12px;color:#94a3b8"></span></h3>
+        <p style="font-size:12px;color:#94a3b8;margin-bottom:8px">Fuzzy-matched store names that look like the same merchant</p>
+        <button class="btn btn-outline btn-sm" id="discoverStorePairsBtn" style="margin-bottom:8px">Discover Unpaired Stores</button>
+        <div id="suggestedPairsSection" class="hidden">
+            <div class="scroll-table" style="max-height:250px"><table><thead><tr><th>Raw Name</th><th>Suggested Normal</th><th>Txns</th><th></th></tr></thead><tbody id="suggestedPairsBody"></tbody></table></div>
+            <button class="btn btn-success btn-sm" id="acceptAllPairsBtn" style="margin-top:8px">Accept All</button>
+        </div>
+        <h3 style="margin-top:16px;font-size:14px">Duplicate Stores <span id="duplicatesCount" style="font-size:12px;color:#94a3b8"></span></h3>
+        <p style="font-size:12px;color:#94a3b8;margin-bottom:8px">Normalized names that look like the same merchant (fuzzy match)</p>
+        <button class="btn btn-outline btn-sm" id="detectDuplicatesBtn" style="margin-bottom:8px">Detect Duplicates</button>
+        <div id="duplicatesSection" class="hidden">
+            <div class="scroll-table" style="max-height:300px"><table><thead><tr><th>Suggested Name</th><th>Variants</th><th>Txns</th><th></th></tr></thead><tbody id="duplicatesBody"></tbody></table></div>
+            <button class="btn btn-success btn-sm" id="consolidateAllBtn" style="margin-top:8px">Consolidate All</button>
+        </div>
+    </div>
+    <div class="section">
+        <h2>Recycle Bin</h2>
+        <div class="scroll-table"><table><thead><tr><th>Date</th><th>Store</th><th>Amount</th><th>Actions</th></tr></thead><tbody id="recycleBody"></tbody></table></div>
+    </div>
+</div>
+
+<!-- BUDGETS TAB -->
+<div id="tab-budgets" class="hidden">
+    <div class="section">
+        <h2>Budget vs Actual</h2>
+        <div class="form-row">
+            <label style="color:#94a3b8;font-size:13px">Month:</label>
+            <select id="budgetMonth"></select>
+        </div>
+        <canvas id="budgetChart" style="max-height:350px"></canvas>
+    </div>
+    <div class="section">
+        <h2>Set Budget</h2>
+        <div class="form-row">
+            <input type="month" id="newBudgetMonth" placeholder="YYYY-MM">
+            <select id="newBudgetCat"></select>
+            <input type="number" id="newBudgetAmt" placeholder="Amount" step="50" style="width:100px">
+            <button class="btn" id="setBudgetBtn">Set</button>
+        </div>
+        <div class="form-row">
+            <input type="month" id="copyFromMonth" placeholder="From">
+            <input type="month" id="copyToMonth" placeholder="To">
+            <button class="btn" id="copyBudgetBtn">Copy Month</button>
+        </div>
+        <div class="scroll-table"><table><thead><tr><th>Month</th><th>Category</th><th>Budget</th><th>Status</th></tr></thead><tbody id="budgetBody"></tbody></table></div>
+    </div>
+</div>
+
+<!-- REIMBURSE TAB -->
+<div id="tab-reimburse" class="hidden">
+    <div class="section">
+        <h2>Reimbursers <span id="reimbursersCount" style="font-size:12px;color:#94a3b8"></span></h2>
+        <p class="subtitle">Track income sources that offset specific expenses (e.g. Canada Life covering wellness costs).</p>
+        <div class="form-row">
+            <input type="text" id="newReimburserPattern" placeholder="Pattern (e.g. canada life)" list="dl-income-stores">
+            <input type="text" id="newReimburserLabel" placeholder="Label (optional)">
+            <select id="newReimburserType"><option value="substring">substring</option><option value="exact">exact</option></select>
+            <button class="btn" id="addReimburserBtn">Add Reimburser</button>
+        </div>
+        <div class="scroll-table" style="max-height:200px"><table><thead><tr><th>Pattern</th><th>Label</th><th>Match</th><th></th></tr></thead><tbody id="reimbursersBody"></tbody></table></div>
+        <h3 style="margin-top:16px;font-size:14px">Reimburser Pairs <span id="reimbPairsCount" style="font-size:12px;color:#94a3b8"></span></h3>
+        <p style="font-size:12px;color:#94a3b8;margin-bottom:8px">Link a reimburser to the expense they typically cover</p>
+        <div class="form-row">
+            <input type="text" id="newPairReimburser" placeholder="Reimburser pattern (e.g. canada life)" list="dl-income-stores">
+            <input type="text" id="newPairExpense" placeholder="Expense pattern (e.g. humanity wellness)" list="dl-expense-stores">
+            <button class="btn" id="addReimbPairBtn">Add Pair</button>
+            <button class="btn btn-outline" id="discoverPairsBtn">Discover from History</button>
+        </div>
+        <div class="scroll-table" style="max-height:150px"><table><thead><tr><th>Reimburser</th><th>Expense</th><th></th></tr></thead><tbody id="reimburserPairsBody"></tbody></table></div>
+        <div id="discoveredPairs" class="hidden" style="margin-top:12px">
+            <h4 style="font-size:13px;color:#fbbf24;margin-bottom:8px">Discovered Patterns</h4>
+            <div class="scroll-table" style="max-height:150px"><table><thead><tr><th>Reimburser</th><th>Expense</th><th>Links</th><th></th></tr></thead><tbody id="discoveredPairsBody"></tbody></table></div>
+            <button class="btn btn-success btn-sm" id="acceptAllDiscoveredBtn" style="margin-top:8px">Accept All</button>
+        </div>
+        <h3 style="margin-top:16px;font-size:14px">Pending Reimbursements</h3>
+        <p style="font-size:12px;color:#94a3b8;margin-bottom:8px">Income from known reimbursers not yet linked to an expense.</p>
+        <div class="scroll-table" style="max-height:300px"><table><thead><tr><th>Date</th><th>From</th><th>Amount</th><th>Suggested Expense</th><th>Actions</th></tr></thead><tbody id="pendingReimbBody" data-testid="pending-reimb-body"></tbody></table></div>
+    </div>
+</div>
+
+<!-- TRIPS TAB -->
+<div id="tab-trips" class="hidden">
+    <div class="section">
+        <h2>Trips</h2>
+        <p class="subtitle">Tag a date range as a trip to track shared expenses and calculate splits.</p>
+        <div class="form-row">
+            <input type="text" id="newTripName" placeholder="Trip name (e.g. Pemberton Weekend)">
+            <input type="date" id="newTripStart">
+            <input type="date" id="newTripEnd">
+            <input type="text" id="newTripNotes" placeholder="Notes (optional)" style="width:160px">
+            <button class="btn btn-success" id="createTripBtn">Create &amp; Auto-assign</button>
+        </div>
+        <div class="scroll-table" style="margin-top:16px"><table><thead><tr><th>Name</th><th>Dates</th><th>Txns</th><th>Total Spend</th><th>Notes</th><th></th></tr></thead><tbody id="tripsBody"></tbody></table></div>
+    </div>
+    <div id="tripDetailSection" class="section hidden">
+        <div style="display:flex;gap:12px;align-items:center;margin-bottom:16px">
+            <h2 id="tripDetailName" style="margin:0"></h2>
+            <span id="tripDetailDates" style="font-size:13px;color:#94a3b8"></span>
+            <button class="btn btn-sm btn-outline" onclick="App.closeTripDetail()">&#x2715; Close</button>
+        </div>
+        <div style="display:flex;gap:16px;align-items:center;margin-bottom:16px;flex-wrap:wrap">
+            <span id="tripDetailTotal" style="font-size:18px;font-weight:600;color:#f87171"></span>
+            <span style="font-size:13px;color:#94a3b8">Split:</span>
+            <input type="number" id="tripSplitPct" value="60" min="0" max="100" step="5" style="width:60px;background:#0f172a;border:1px solid #334155;color:#f8fafc;padding:4px 8px;border-radius:4px;font-size:13px"> <span style="font-size:13px;color:#94a3b8">% your share</span>
+            <span id="tripSplitResult" style="font-size:15px;font-weight:600;color:#4ade80"></span>
+        </div>
+        <div class="scroll-table"><table><thead><tr><th>Date</th><th>Store</th><th>Category</th><th>Amount</th><th></th></tr></thead><tbody id="tripTxnBody"></tbody></table></div>
     </div>
 </div>
 
@@ -654,156 +839,6 @@ input[type="checkbox"] { accent-color: #3b82f6; width: 14px; height: 14px; curso
     </div>
 </div>
 
-<!-- CATEGORIZE TAB -->
-<div id="tab-categorize" class="hidden">
-    <div class="section" style="display:flex;gap:12px;align-items:center;padding:16px 20px">
-        <button class="btn btn-success" id="recatAllBtn" data-testid="recategorize-btn">Re-categorize All Uncategorized</button>
-        <span id="recatResult" data-testid="recategorize-result" style="font-size:13px;color:#94a3b8"></span>
-    </div>
-    <div id="uncategorizedSection" class="section">
-        <h2>Uncategorized Merchants</h2>
-        <p class="subtitle">Select a category to auto-classify all transactions from that merchant</p>
-        <div class="scroll-table"><table><thead><tr><th>Store</th><th>Count</th><th>Total Spend</th><th>Category</th></tr></thead><tbody id="uncatBody"></tbody></table></div>
-    </div>
-    <div id="suggestSection" class="section">
-        <h2>Keyword Suggestions</h2>
-        <p class="subtitle">Auto-detected categories based on store name keywords</p>
-        <div style="margin-bottom:12px"><button class="btn btn-success" id="applyAllSuggBtn">Apply All</button></div>
-        <div class="scroll-table"><table><thead><tr><th>Store</th><th>Suggested</th><th>Amount</th><th>Count</th><th>Actions</th></tr></thead><tbody id="suggestBody"></tbody></table></div>
-    </div>
-    <div class="section">
-        <h2>Category Rules <span id="rulesCount" style="font-size:12px;color:#94a3b8"></span></h2>
-        <div class="form-row">
-            <input type="text" id="newRulePattern" placeholder="Pattern (store name)" list="dl-expense-stores">
-            <select id="newRuleCat"></select>
-            <select id="newRuleType"><option value="exact">exact</option><option value="substring">substring</option></select>
-            <button class="btn" id="addRuleBtn">Add Rule</button>
-        </div>
-        <div class="form-row">
-            <input type="text" id="rulesSearch" placeholder="Search rules..." style="width:250px">
-        </div>
-        <div class="scroll-table" style="max-height:300px"><table><thead><tr><th>Pattern</th><th>Category</th><th>Match Type</th></tr></thead><tbody id="rulesBody"></tbody></table></div>
-    </div>
-</div>
-
-<!-- BUDGETS TAB -->
-<div id="tab-budgets" class="hidden">
-    <div class="section">
-        <h2>Budget vs Actual</h2>
-        <div class="form-row">
-            <label style="color:#94a3b8;font-size:13px">Month:</label>
-            <select id="budgetMonth"></select>
-        </div>
-        <canvas id="budgetChart" style="max-height:350px"></canvas>
-    </div>
-    <div class="section">
-        <h2>Set Budget</h2>
-        <div class="form-row">
-            <input type="month" id="newBudgetMonth" placeholder="YYYY-MM">
-            <select id="newBudgetCat"></select>
-            <input type="number" id="newBudgetAmt" placeholder="Amount" step="50" style="width:100px">
-            <button class="btn" id="setBudgetBtn">Set</button>
-        </div>
-        <div class="form-row">
-            <input type="month" id="copyFromMonth" placeholder="From">
-            <input type="month" id="copyToMonth" placeholder="To">
-            <button class="btn" id="copyBudgetBtn">Copy Month</button>
-        </div>
-        <div class="scroll-table"><table><thead><tr><th>Month</th><th>Category</th><th>Budget</th><th>Status</th></tr></thead><tbody id="budgetBody"></tbody></table></div>
-    </div>
-</div>
-
-<!-- MANAGE TAB -->
-<div id="tab-manage" class="hidden">
-    <div class="section">
-        <h2>Store Pairs <span id="pairsCount" style="font-size:12px;color:#94a3b8"></span></h2>
-        <div class="form-row">
-            <input type="text" id="newPairRaw" placeholder="Raw name" list="dl-expense-raw">
-            <input type="text" id="newPairNorm" placeholder="Normalized name" list="dl-all-stores">
-            <button class="btn" id="addPairBtn">Add Pair</button>
-        </div>
-        <div class="form-row">
-            <input type="text" id="pairsSearch" placeholder="Search pairs..." style="width:250px">
-        </div>
-        <div class="scroll-table" style="max-height:300px"><table><thead><tr><th>Raw Name</th><th>Normalized</th><th></th></tr></thead><tbody id="pairsBody"></tbody></table></div>
-        <h3 style="margin-top:16px;font-size:14px">Suggested Pairs <span id="suggestedPairsCount" style="font-size:12px;color:#94a3b8"></span></h3>
-        <p style="font-size:12px;color:#94a3b8;margin-bottom:8px">Fuzzy-matched store names that look like the same merchant</p>
-        <button class="btn btn-outline btn-sm" id="discoverStorePairsBtn" style="margin-bottom:8px">Discover Unpaired Stores</button>
-        <div id="suggestedPairsSection" class="hidden">
-            <div class="scroll-table" style="max-height:250px"><table><thead><tr><th>Raw Name</th><th>Suggested Normal</th><th>Txns</th><th></th></tr></thead><tbody id="suggestedPairsBody"></tbody></table></div>
-            <button class="btn btn-success btn-sm" id="acceptAllPairsBtn" style="margin-top:8px">Accept All</button>
-        </div>
-        <h3 style="margin-top:16px;font-size:14px">Duplicate Stores <span id="duplicatesCount" style="font-size:12px;color:#94a3b8"></span></h3>
-        <p style="font-size:12px;color:#94a3b8;margin-bottom:8px">Normalized names that look like the same merchant (fuzzy match)</p>
-        <button class="btn btn-outline btn-sm" id="detectDuplicatesBtn" style="margin-bottom:8px">Detect Duplicates</button>
-        <div id="duplicatesSection" class="hidden">
-            <div class="scroll-table" style="max-height:300px"><table><thead><tr><th>Suggested Name</th><th>Variants</th><th>Txns</th><th></th></tr></thead><tbody id="duplicatesBody"></tbody></table></div>
-            <button class="btn btn-success btn-sm" id="consolidateAllBtn" style="margin-top:8px">Consolidate All</button>
-        </div>
-    </div>
-    <div class="section">
-        <h2>Reimbursers <span id="reimbursersCount" style="font-size:12px;color:#94a3b8"></span></h2>
-        <div class="form-row">
-            <input type="text" id="newReimburserPattern" placeholder="Pattern (e.g. friend name)" list="dl-income-stores">
-            <input type="text" id="newReimburserLabel" placeholder="Label (optional)">
-            <select id="newReimburserType"><option value="substring">substring</option><option value="exact">exact</option></select>
-            <button class="btn" id="addReimburserBtn">Add Reimburser</button>
-        </div>
-        <div class="scroll-table" style="max-height:200px"><table><thead><tr><th>Pattern</th><th>Label</th><th>Match</th><th></th></tr></thead><tbody id="reimbursersBody"></tbody></table></div>
-        <h3 style="margin-top:16px;font-size:14px">Reimburser Pairs <span id="reimbPairsCount" style="font-size:12px;color:#94a3b8"></span></h3>
-        <p style="font-size:12px;color:#94a3b8;margin-bottom:8px">Link a reimburser to the expense they typically cover</p>
-        <div class="form-row">
-            <input type="text" id="newPairReimburser" placeholder="Reimburser pattern (e.g. canada life)" list="dl-income-stores">
-            <input type="text" id="newPairExpense" placeholder="Expense pattern (e.g. humanity wellness)" list="dl-expense-stores">
-            <button class="btn" id="addReimbPairBtn">Add Pair</button>
-            <button class="btn btn-outline" id="discoverPairsBtn">Discover from History</button>
-        </div>
-        <div class="scroll-table" style="max-height:150px"><table><thead><tr><th>Reimburser</th><th>Expense</th><th></th></tr></thead><tbody id="reimburserPairsBody"></tbody></table></div>
-        <div id="discoveredPairs" class="hidden" style="margin-top:12px">
-            <h4 style="font-size:13px;color:#fbbf24;margin-bottom:8px">Discovered Patterns</h4>
-            <div class="scroll-table" style="max-height:150px"><table><thead><tr><th>Reimburser</th><th>Expense</th><th>Links</th><th></th></tr></thead><tbody id="discoveredPairsBody"></tbody></table></div>
-            <button class="btn btn-success btn-sm" id="acceptAllDiscoveredBtn" style="margin-top:8px">Accept All</button>
-        </div>
-        <h3 style="margin-top:16px;font-size:14px">Pending Reimbursements</h3>
-        <p style="font-size:12px;color:#94a3b8;margin-bottom:8px">Income from known reimbursers not yet linked to an expense. Suggested matches shown when pairs are configured.</p>
-        <div class="scroll-table" style="max-height:300px"><table><thead><tr><th>Date</th><th>From</th><th>Amount</th><th>Suggested Expense</th><th>Actions</th></tr></thead><tbody id="pendingReimbBody" data-testid="pending-reimb-body"></tbody></table></div>
-    </div>
-    <div class="section">
-        <h2>Recycle Bin</h2>
-        <div class="scroll-table"><table><thead><tr><th>Date</th><th>Store</th><th>Amount</th><th>Actions</th></tr></thead><tbody id="recycleBody"></tbody></table></div>
-    </div>
-</div>
-
-<!-- TRANSACTION TABLE (always visible below tabs) -->
-<div class="filters">
-    <div><label>Search</label><br><input type="text" id="searchInput" placeholder="Store, category..."></div>
-    <div><label>Category</label><br><select id="categoryFilter"><option value="">All</option></select></div>
-    <div><label>Month</label><br><select id="monthFilter"><option value="">All</option></select></div>
-    <div><label>Type</label><br><select id="typeFilter"><option value="">All</option><option value="expense">Expenses</option><option value="income">Income</option></select></div>
-    <div><label>From</label><br><input type="date" id="dateFrom" style="width:130px"></div>
-    <div><label>To</label><br><input type="date" id="dateTo" style="width:130px"></div>
-    <div><label>Min $</label><br><input type="number" id="minAmount" style="width:80px" step="0.01"></div>
-    <div><label>Max $</label><br><input type="number" id="maxAmount" style="width:80px" step="0.01"></div>
-    <div style="margin-left:auto;align-self:flex-end"><button class="btn btn-outline" id="exportCsvBtn" data-testid="export-csv-btn">Export CSV</button></div>
-</div>
-<div id="bulkBar" class="bulk-bar hidden" data-testid="bulk-bar">
-    <span><span class="count" id="bulkCount">0</span> selected</span>
-    <select id="bulkCatSelect" class="inline-cat-select"><option value="">Assign category...</option></select>
-    <button class="btn btn-sm btn-success" id="bulkCatBtn">Apply</button>
-    <button class="btn btn-sm btn-danger" id="bulkDeleteBtn">Delete Selected</button>
-    <button class="btn btn-sm btn-outline" id="bulkClearBtn">Clear</button>
-</div>
-<div class="table-wrap">
-    <h2>Transactions</h2>
-    <div class="txn-count" id="txnCount"></div>
-    <div class="scroll-table">
-        <table id="txnTable" data-testid="txn-table">
-            <thead><tr><th><input type="checkbox" id="selectAll" data-testid="select-all"></th><th data-col="date">Date</th><th data-col="store">Store</th><th data-col="category">Category</th><th data-col="amount">Amount</th><th data-col="type">Type</th><th>Actions</th></tr></thead>
-            <tbody id="txnBody" data-testid="txn-body"></tbody>
-        </table>
-    </div>
-</div>
-
 <datalist id="dl-expense-stores"></datalist>
 <datalist id="dl-expense-raw"></datalist>
 <datalist id="dl-income-stores"></datalist>
@@ -834,15 +869,16 @@ async function apiPost(path, data) {
 
 // --- App State ---
 const App = {
-    data: { transactions: [], summary: {}, budgets: [], rules: [], storePairs: {}, history: [], anomalies: [], uncategorized: [], suggestions: [], deleted: [], analytics: {} },
+    data: { transactions: [], summary: {}, budgets: [], rules: [], storePairs: {}, history: [], anomalies: [], uncategorized: [], suggestions: [], deleted: [], analytics: {}, trips: [] },
     charts: {},
+    _currentTrip: null,
 
     _txnPage: 0,
     _txnPageSize: 500,
     _txnTotal: 0,
 
     async init() {
-        const [txns, overview, budgets, rules, pairs, history, uncat, suggest, deleted, reimbursers, pendingReimb, reimburserPairs, stores] = await Promise.all([
+        const [txns, overview, budgets, rules, pairs, history, uncat, suggest, deleted, reimbursers, pendingReimb, reimburserPairs, stores, trips] = await Promise.all([
             api(`/api/transactions?offset=0&limit=${this._txnPageSize}`),
             api('/api/overview'),
             api('/api/budgets'),
@@ -851,6 +887,7 @@ const App = {
             api('/api/transactions/deleted'),
             api('/api/reimbursers'), api('/api/reimbursements/pending'),
             api('/api/reimburser-pairs'), api('/api/stores'),
+            api('/api/trips'),
         ]);
         this.data.transactions = txns.transactions || [];
         this._txnTotal = txns.total || this.data.transactions.length;
@@ -870,6 +907,7 @@ const App = {
         this.data.reimburserPairs = reimburserPairs.pairs || [];
         this.data.expenseStores = stores.expenses || [];
         this.data.incomeStores = stores.income || [];
+        this.data.trips = trips.trips || [];
         this.renderAll();
         this.populateDataLists();
     },
@@ -910,6 +948,7 @@ const App = {
         this.renderReimbursers();
         this.renderHistory();
         this.renderRecycleBin();
+        this.renderTrips();
         this.populateFilters();
         this.renderTable();
     },
@@ -1443,6 +1482,78 @@ const App = {
         await this.refresh();
     },
 
+    renderTrips() {
+        const body = document.getElementById('tripsBody');
+        if (!body) return;
+        if (!this.data.trips.length) {
+            body.innerHTML = '<tr><td colspan="6" style="color:#94a3b8;text-align:center;padding:24px">No trips yet. Create one above.</td></tr>';
+            return;
+        }
+        body.innerHTML = this.data.trips.map(t =>
+            `<tr>
+                <td><button class="btn btn-sm btn-outline" onclick="App.openTrip(${t.id})">${t.name}</button></td>
+                <td style="font-size:12px;color:#94a3b8">${t.start_date} – ${t.end_date}</td>
+                <td>${t.txn_count}</td>
+                <td style="color:#f87171">$${(t.total_spend||0).toFixed(2)}</td>
+                <td style="font-size:12px;color:#64748b">${t.notes||''}</td>
+                <td><button class="btn btn-sm btn-danger" onclick="App.deleteTrip(${t.id})">Del</button></td>
+            </tr>`
+        ).join('');
+    },
+
+    async openTrip(tripId) {
+        const data = await api(`/api/trips/${tripId}`);
+        this._currentTrip = data;
+        const sec = document.getElementById('tripDetailSection');
+        document.getElementById('tripDetailName').textContent = data.trip.name;
+        document.getElementById('tripDetailDates').textContent = `${data.trip.start_date} – ${data.trip.end_date}`;
+        const txns = data.transactions || [];
+        const total = txns.filter(t => t.type === 'expense').reduce((s, t) => s + t.amount, 0);
+        document.getElementById('tripDetailTotal').textContent = `Total: $${total.toFixed(2)}`;
+        this._renderTripSplit(total);
+        document.getElementById('tripTxnBody').innerHTML = txns.map(t =>
+            `<tr>
+                <td>${t.date}</td>
+                <td>${t.store_normalized||t.store_raw}</td>
+                <td>${catBadge(t.category)}</td>
+                <td style="color:${t.type==='income'?'#4ade80':'#f87171'}">${t.type==='income'?'+':'-'}$${t.amount.toFixed(2)}</td>
+                <td><button class="btn btn-sm btn-danger" onclick="App.removeTripTxn(${tripId},'${t.uuid}')">Remove</button></td>
+            </tr>`
+        ).join('');
+        sec.classList.remove('hidden');
+        document.getElementById('tripSplitPct').oninput = () => {
+            const total2 = (this._currentTrip?.transactions||[]).filter(t=>t.type==='expense').reduce((s,t)=>s+t.amount,0);
+            this._renderTripSplit(total2);
+        };
+    },
+
+    _renderTripSplit(total) {
+        const pct = parseFloat(document.getElementById('tripSplitPct').value) || 60;
+        const mine = total * pct / 100;
+        const theirs = total - mine;
+        document.getElementById('tripSplitResult').textContent =
+            `You: $${mine.toFixed(2)} · Partner: $${theirs.toFixed(2)}`;
+    },
+
+    closeTripDetail() {
+        document.getElementById('tripDetailSection').classList.add('hidden');
+        this._currentTrip = null;
+    },
+
+    async deleteTrip(tripId) {
+        await api(`/api/trips/${tripId}`, {method:'DELETE'});
+        toast('Trip deleted');
+        await this.refresh();
+    },
+
+    async removeTripTxn(tripId, txnUuid) {
+        await api(`/api/trips/${tripId}/transactions/${txnUuid}`, {method:'DELETE'});
+        await this.openTrip(tripId);
+        const data = await api('/api/trips');
+        this.data.trips = data.trips || [];
+        this.renderTrips();
+    },
+
     showLinkModal(expenseUuid) {
         this._linkExpenseUuid = expenseUuid;
         const incomes = this.data.transactions.filter(t => t.type === 'income');
@@ -1535,6 +1646,9 @@ const App = {
                 : hasOffset
                 ? `<button class="btn btn-sm btn-outline" onclick="App.unlinkTxn('${t.uuid}')" title="Remove offset" style="color:#f59e0b">Ulk</button>`
                 : '';
+            const tripNames = (this.data.trips||[]).filter(trip => {
+                return trip.start_date <= t.date && t.date <= trip.end_date;
+            }).map(trip => `<span style="font-size:11px;background:#1e3a5f;color:#93c5fd;padding:1px 6px;border-radius:4px;cursor:pointer" onclick="App.openTrip(${trip.id})">${trip.name}</span>`).join(' ');
             return `<tr${hasOffset ? ' style="background:#fefce8"' : ''}>
                 <td><input type="checkbox" data-uuid="${t.uuid}" ${checked} onchange="App.toggleSelect('${t.uuid}', this.checked)"></td>
                 <td>${t.date}</td>
@@ -1542,6 +1656,7 @@ const App = {
                 <td>${catBadge(t.category)} <select class="inline-cat-select" onchange="App.inlineCategory('${t.uuid}', this.value)"><option value="">edit</option>${catOpts}</select></td>
                 <td style="text-align:right;font-variant-numeric:tabular-nums">${t.type==='income'?'+':'-'}${amtDisplay}</td>
                 <td>${t.type}</td>
+                <td>${tripNames}</td>
                 <td style="display:flex;gap:4px">${linkBtn}<button class="btn btn-sm btn-danger" onclick="App.deleteTxn('${t.uuid}')">Del</button></td>
             </tr>`;
         }).join('');
@@ -1611,11 +1726,12 @@ const App = {
 };
 
 // --- Tab switching ---
+const ALL_TABS = ['overview','transactions','organize','budgets','reimburse','trips','analytics','import'];
 document.querySelectorAll('.tab').forEach(tab => {
     tab.addEventListener('click', () => {
         document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
         tab.classList.add('active');
-        ['overview','analytics','import','categorize','budgets','manage'].forEach(name => {
+        ALL_TABS.forEach(name => {
             document.getElementById('tab-'+name).classList.toggle('hidden', name !== tab.dataset.tab);
         });
     });
@@ -1790,6 +1906,20 @@ async function doImport(filename, btn) {
         }
     }
 }
+
+// --- Trips ---
+document.getElementById('createTripBtn').addEventListener('click', async () => {
+    const name = document.getElementById('newTripName').value.trim();
+    const start = document.getElementById('newTripStart').value;
+    const end = document.getElementById('newTripEnd').value;
+    const notes = document.getElementById('newTripNotes').value.trim();
+    if (!name || !start || !end) { toast('Name, start and end date required'); return; }
+    const r = await apiPost('/api/trips', {name, start_date: start, end_date: end, notes, auto_assign: true});
+    toast(`Trip created, ${r.assigned} transactions assigned`);
+    document.getElementById('newTripName').value = '';
+    document.getElementById('newTripNotes').value = '';
+    await App.refresh();
+});
 
 // --- Init ---
 App.init();

--- a/smtm/dashboard.py
+++ b/smtm/dashboard.py
@@ -23,6 +23,7 @@ def _txns_to_json(txns: list[Transaction]) -> list[dict]:
             "uuid": t.uuid,
             "linked_to": t.linked_to,
             "adjustment": round(t.adjustment, 2),
+            "deleted_at": t.deleted_at,
         }
         for t in txns
     ]
@@ -503,9 +504,7 @@ def generate_server_html() -> str:
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
 body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif; background: #0f172a; color: #e2e8f0; padding: 20px; }
-.header { text-align: center; margin-bottom: 30px; }
-.header h1 { font-size: 28px; color: #f8fafc; letter-spacing: -0.5px; }
-.header p { color: #94a3b8; margin-top: 4px; }
+.header { margin-bottom: 8px; border-bottom: 1px solid #1e293b; }
 .cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 16px; margin-bottom: 30px; }
 .card { background: #1e293b; border-radius: 12px; padding: 20px; }
 .card .label { font-size: 12px; color: #94a3b8; text-transform: uppercase; letter-spacing: 0.5px; }
@@ -574,12 +573,12 @@ input[type="checkbox"] { accent-color: #3b82f6; width: 14px; height: 14px; curso
 </head>
 <body>
 
-<div class="header" style="display:flex;align-items:center;justify-content:space-between">
-    <div>
-        <h1>show-me-the-money</h1>
-        <p id="headerSub">Loading...</p>
+<div class="header" style="display:flex;align-items:center;justify-content:space-between;padding:12px 24px">
+    <div style="display:flex;align-items:baseline;gap:16px;flex-wrap:wrap">
+        <span style="font-size:13px;color:#475569;font-weight:500;letter-spacing:0.05em;text-transform:uppercase">smtm</span>
+        <span id="headerSub" style="font-size:13px;color:#64748b">Loading...</span>
     </div>
-    <a href="/api/report/pdf" class="btn btn-outline" data-testid="export-pdf-btn" download="financial_report.pdf" style="white-space:nowrap">Download PDF</a>
+    <a href="/api/report/pdf" class="btn btn-outline" data-testid="export-pdf-btn" download="financial_report.pdf" style="white-space:nowrap;font-size:12px">PDF</a>
 </div>
 
 <div class="cards" id="cards" data-testid="summary-cards"></div>
@@ -618,7 +617,7 @@ input[type="checkbox"] { accent-color: #3b82f6; width: 14px; height: 14px; curso
         <div><label>Search</label><br><input type="text" id="searchInput" placeholder="Store, category..."></div>
         <div><label>Category</label><br><select id="categoryFilter"><option value="">All</option></select></div>
         <div><label>Month</label><br><select id="monthFilter"><option value="">All</option></select></div>
-        <div><label>Type</label><br><select id="typeFilter"><option value="">All</option><option value="expense">Expenses</option><option value="income">Income</option></select></div>
+        <div><label>Type</label><br><select id="typeFilter"><option value="">All</option><option value="expense">Expenses</option><option value="income">Income</option><option value="transfer">Transfers</option></select></div>
         <div><label>From</label><br><input type="date" id="dateFrom" style="width:130px"></div>
         <div><label>To</label><br><input type="date" id="dateTo" style="width:130px"></div>
         <div><label>Min $</label><br><input type="number" id="minAmount" style="width:80px" step="0.01"></div>
@@ -671,7 +670,7 @@ input[type="checkbox"] { accent-color: #3b82f6; width: 14px; height: 14px; curso
         <div class="form-row">
             <input type="text" id="rulesSearch" placeholder="Search rules..." style="width:250px">
         </div>
-        <div class="scroll-table" style="max-height:300px"><table><thead><tr><th>Pattern</th><th>Category</th><th>Match Type</th></tr></thead><tbody id="rulesBody"></tbody></table></div>
+        <div class="scroll-table" style="max-height:300px"><table><thead><tr><th>When...</th><th>Category</th><th>Covers</th></tr></thead><tbody id="rulesBody"></tbody></table></div>
     </div>
     <div class="section">
         <h2>Store Pairs <span id="pairsCount" style="font-size:12px;color:#94a3b8"></span></h2>
@@ -684,7 +683,7 @@ input[type="checkbox"] { accent-color: #3b82f6; width: 14px; height: 14px; curso
         <div class="form-row">
             <input type="text" id="pairsSearch" placeholder="Search pairs..." style="width:250px">
         </div>
-        <div class="scroll-table" style="max-height:300px"><table><thead><tr><th>Raw Name</th><th>Normalized</th><th></th></tr></thead><tbody id="pairsBody"></tbody></table></div>
+        <div class="scroll-table" style="max-height:300px"><table><thead><tr><th>Normalized name</th><th></th></tr></thead><tbody id="pairsBody"></tbody></table></div>
         <h3 style="margin-top:16px;font-size:14px">Suggested Pairs <span id="suggestedPairsCount" style="font-size:12px;color:#94a3b8"></span></h3>
         <p style="font-size:12px;color:#94a3b8;margin-bottom:8px">Fuzzy-matched store names that look like the same merchant</p>
         <button class="btn btn-outline btn-sm" id="discoverStorePairsBtn" style="margin-bottom:8px">Discover Unpaired Stores</button>
@@ -702,7 +701,7 @@ input[type="checkbox"] { accent-color: #3b82f6; width: 14px; height: 14px; curso
     </div>
     <div class="section">
         <h2>Recycle Bin</h2>
-        <div class="scroll-table"><table><thead><tr><th>Date</th><th>Store</th><th>Amount</th><th>Actions</th></tr></thead><tbody id="recycleBody"></tbody></table></div>
+        <div class="scroll-table"><table><thead><tr><th>Date</th><th>Store / Category</th><th>Amount</th><th>Deleted</th><th></th></tr></thead><tbody id="recycleBody"></tbody></table></div>
     </div>
 </div>
 
@@ -756,7 +755,7 @@ input[type="checkbox"] { accent-color: #3b82f6; width: 14px; height: 14px; curso
         <div class="scroll-table" style="max-height:150px"><table><thead><tr><th>Reimburser</th><th>Expense</th><th></th></tr></thead><tbody id="reimburserPairsBody"></tbody></table></div>
         <div id="discoveredPairs" class="hidden" style="margin-top:12px">
             <h4 style="font-size:13px;color:#fbbf24;margin-bottom:8px">Discovered Patterns</h4>
-            <div class="scroll-table" style="max-height:150px"><table><thead><tr><th>Reimburser</th><th>Expense</th><th>Links</th><th></th></tr></thead><tbody id="discoveredPairsBody"></tbody></table></div>
+            <div class="scroll-table" style="max-height:300px"><table><thead><tr><th>Pattern &amp; examples</th><th></th></tr></thead><tbody id="discoveredPairsBody"></tbody></table></div>
             <button class="btn btn-success btn-sm" id="acceptAllDiscoveredBtn" style="margin-top:8px">Accept All</button>
         </div>
         <h3 style="margin-top:16px;font-size:14px">Pending Reimbursements</h3>
@@ -777,6 +776,10 @@ input[type="checkbox"] { accent-color: #3b82f6; width: 14px; height: 14px; curso
             <input type="text" id="newTripNotes" placeholder="Notes (optional)" style="width:160px">
             <button class="btn btn-success" id="createTripBtn">Create &amp; Auto-assign</button>
         </div>
+        <div style="margin-top:8px">
+            <label style="font-size:12px;color:#94a3b8;display:block;margin-bottom:4px">Exclude from trip totals:</label>
+            <div id="newTripExcludedCats" style="display:flex;flex-wrap:wrap;gap:8px"></div>
+        </div>
         <div class="scroll-table" style="margin-top:16px"><table><thead><tr><th>Name</th><th>Dates</th><th>Txns</th><th>Total Spend</th><th>Notes</th><th></th></tr></thead><tbody id="tripsBody"></tbody></table></div>
     </div>
     <div id="tripDetailSection" class="section hidden">
@@ -790,6 +793,11 @@ input[type="checkbox"] { accent-color: #3b82f6; width: 14px; height: 14px; curso
             <span style="font-size:13px;color:#94a3b8">Split:</span>
             <input type="number" id="tripSplitPct" value="60" min="0" max="100" step="5" style="width:60px;background:#0f172a;border:1px solid #334155;color:#f8fafc;padding:4px 8px;border-radius:4px;font-size:13px"> <span style="font-size:13px;color:#94a3b8">% your share</span>
             <span id="tripSplitResult" style="font-size:15px;font-weight:600;color:#4ade80"></span>
+        </div>
+        <div style="margin-bottom:12px">
+            <label style="font-size:12px;color:#94a3b8;display:block;margin-bottom:4px">Exclude from totals:</label>
+            <div id="tripExcludedCats" style="display:flex;flex-wrap:wrap;gap:8px"></div>
+            <button class="btn btn-sm btn-outline" id="saveTripExclusionsBtn" style="margin-top:6px">Save exclusions &amp; recompute</button>
         </div>
         <div class="scroll-table"><table><thead><tr><th>Date</th><th>Store</th><th>Category</th><th>Amount</th><th></th></tr></thead><tbody id="tripTxnBody"></tbody></table></div>
     </div>
@@ -949,14 +957,34 @@ const App = {
         this.renderHistory();
         this.renderRecycleBin();
         this.renderTrips();
+        this.renderTripCreateExcludes();
         this.populateFilters();
         this.renderTable();
     },
 
+    renderTripCreateExcludes(currentExcluded) {
+        const cats = this.data.summary.categories || [];
+        const excluded = currentExcluded !== undefined ? currentExcluded : ['Investments'];
+        const excludedSet = new Set(excluded);
+        const container = document.getElementById('newTripExcludedCats');
+        if (container) {
+            container.innerHTML = cats.map(c =>
+                `<label style="font-size:12px;color:#cbd5e1"><input type="checkbox" value="${c}" ${excludedSet.has(c)?'checked':''}> ${c}</label>`
+            ).join(' ');
+        }
+    },
+
     renderHeader() {
         const s = this.data.summary;
-        document.getElementById('headerSub').textContent =
-            `${s.date_min || '?'} to ${s.date_max || '?'} · ${s.num_months || 0} months · ${s.total_transactions || 0} transactions`;
+        const net = (s.net_savings || 0);
+        const netColor = net >= 0 ? '#4ade80' : '#f87171';
+        const netStr = (net >= 0 ? '+' : '') + '$' + Math.abs(net).toLocaleString(undefined, {maximumFractionDigits: 0});
+        document.getElementById('headerSub').innerHTML =
+            `<span>${s.date_min || '?'} – ${s.date_max || '?'}</span>`
+            + ` <span style="color:#334155">·</span> `
+            + `<span style="color:${netColor};font-weight:600">${netStr}</span> net`
+            + ` <span style="color:#334155">·</span> `
+            + `<span>${s.total_transactions || 0} transactions</span>`;
     },
 
     renderCards() {
@@ -1250,9 +1278,13 @@ const App = {
         const filtered = this.data.rules.filter(r => !search || r.pattern.toLowerCase().includes(search) || r.category.toLowerCase().includes(search));
         document.getElementById('rulesCount').textContent = `(${filtered.length}/${this.data.rules.length})`;
         const body = document.getElementById('rulesBody');
-        body.innerHTML = filtered.map(r =>
-            `<tr><td>${r.pattern}</td><td>${catBadge(r.category)}</td><td>${r.match_type}</td></tr>`
-        ).join('');
+        body.innerHTML = filtered.map(r => {
+            const desc = r.match_type === 'exact'
+                ? `store matches <code style="font-size:11px;background:#0f172a;padding:1px 4px;border-radius:3px">${r.pattern}</code>`
+                : `store contains <code style="font-size:11px;background:#0f172a;padding:1px 4px;border-radius:3px">${r.pattern}</code>`;
+            const count = r.txn_count != null ? `<span style="font-size:11px;color:#94a3b8">${r.txn_count} txn${r.txn_count===1?'':'s'}</span>` : '';
+            return `<tr><td style="font-size:12px">${desc}</td><td>${catBadge(r.category)}</td><td>${count}</td></tr>`;
+        }).join('');
         const catSel = document.getElementById('newRuleCat');
         catSel.innerHTML = (this.data.summary.categories||[]).map(c=>`<option value="${c}">${c}</option>`).join('');
     },
@@ -1260,12 +1292,63 @@ const App = {
     renderStorePairs(filter) {
         const search = (filter || document.getElementById('pairsSearch').value || '').toLowerCase();
         const pairs = this.data.storePairs;
-        const entries = Object.entries(pairs).filter(([raw, norm]) => !search || raw.toLowerCase().includes(search) || norm.toLowerCase().includes(search));
-        document.getElementById('pairsCount').textContent = `(${entries.length}/${Object.keys(pairs).length})`;
+        const allEntries = Object.entries(pairs);
+
+        // Group by normalized name
+        const byNorm = {};
+        for (const [raw, norm] of allEntries) {
+            if (!byNorm[norm]) byNorm[norm] = [];
+            byNorm[norm].push(raw);
+        }
+
+        // Filter groups: keep if norm or any raw matches search
+        const filteredGroups = Object.entries(byNorm).filter(([norm, raws]) => {
+            if (!search) return true;
+            return norm.toLowerCase().includes(search) || raws.some(r => r.toLowerCase().includes(search));
+        });
+        filteredGroups.sort((a, b) => b[1].length - a[1].length || a[0].localeCompare(b[0]));
+
+        const matchedRaws = search
+            ? filteredGroups.reduce((n, [, raws]) => n + raws.filter(r => r.toLowerCase().includes(search) || !search).length, 0)
+            : allEntries.length;
+        document.getElementById('pairsCount').textContent = `(${filteredGroups.length} groups / ${matchedRaws} pairs)`;
+
         const body = document.getElementById('pairsBody');
-        body.innerHTML = entries.map(([raw, norm]) =>
-            `<tr><td style="font-size:12px">${raw}</td><td><input type="text" value="${norm}" data-raw="${raw.replace(/"/g,'&quot;')}" class="pair-norm-input" style="width:100%;background:#0f172a;border:1px solid #334155;color:#f8fafc;padding:4px 8px;border-radius:4px;font-size:12px" list="dl-all-stores"></td><td style="white-space:nowrap"><button class="btn btn-sm btn-success" onclick="App.savePair(this)">Save</button> <button class="btn btn-sm btn-danger" onclick="App.deletePair('${raw.replace(/'/g,"\\'")}')">Del</button></td></tr>`
-        ).join('');
+        body.innerHTML = filteredGroups.map(([norm, raws]) => {
+            const rawsHtml = raws.map(raw => {
+                const dimmed = search && !raw.toLowerCase().includes(search) && !norm.toLowerCase().includes(search) ? 'opacity:0.4;' : '';
+                return `<tr style="${dimmed}background:#0c1929">
+                    <td style="padding-left:24px;font-size:11px;color:#94a3b8;font-family:monospace">${raw}</td>
+                    <td style="white-space:nowrap">
+                        <button class="btn btn-sm btn-danger" onclick="App.deletePair('${raw.replace(/'/g,"\\'")}')">Del</button>
+                    </td>
+                </tr>`;
+            }).join('');
+            return `<tr style="background:#0f172a">
+                <td>
+                    <input type="text" value="${norm}" data-norm="${norm.replace(/"/g,'&quot;')}" class="norm-rename-input"
+                        style="width:220px;background:#0f172a;border:1px solid #334155;color:#f8fafc;padding:3px 8px;border-radius:4px;font-size:13px;font-weight:500" list="dl-all-stores">
+                    <span style="font-size:11px;color:#64748b;margin-left:8px">${raws.length} raw name${raws.length>1?'s':''}</span>
+                </td>
+                <td style="white-space:nowrap">
+                    <button class="btn btn-sm btn-success" onclick="App.renameNorm(this)">Rename all</button>
+                </td>
+            </tr>${rawsHtml}`;
+        }).join('');
+    },
+
+    async renameNorm(btn) {
+        const input = btn.parentElement.parentElement.querySelector('.norm-rename-input');
+        const oldNorm = input.dataset.norm;
+        const newNorm = input.value.trim();
+        if (!newNorm || newNorm === oldNorm) return;
+        const pairs = this.data.storePairs;
+        const raws = Object.entries(pairs).filter(([, n]) => n === oldNorm).map(([r]) => r);
+        for (const raw of raws) {
+            await apiPost('/api/store-pairs', {raw_name: raw, normalized_name: newNorm});
+        }
+        toast(`Renamed "${oldNorm}" → "${newNorm}" (${raws.length} pairs)`);
+        await this.refresh();
     },
 
     async savePair(btn) {
@@ -1413,12 +1496,30 @@ const App = {
     async discoverPairs() {
         const data = await api('/api/reimburser-pairs/discover');
         const discovered = data.discovered || [];
-        if (!discovered.length) { toast('No patterns discovered from history'); return; }
+        if (!discovered.length) { toast('No patterns discovered — link some income transactions to expenses first'); return; }
         this._discoveredPairs = discovered;
         const body = document.getElementById('discoveredPairsBody');
-        body.innerHTML = discovered.map((d, i) =>
-            `<tr><td>${d.reimburser_pattern}</td><td>${d.expense_pattern}</td><td>${d.link_count}</td><td><button class="btn btn-sm btn-success" onclick="App.acceptDiscovered(${i})">Accept</button></td></tr>`
-        ).join('');
+        body.innerHTML = discovered.map((d, i) => {
+            const examples = (d.examples || []).map(e =>
+                `<div style="font-size:11px;color:#94a3b8;padding:2px 0">
+                    <span style="color:#4ade80">+$${e.income_amount.toFixed(2)}</span> ${e.income_store} on ${e.income_date}
+                    &rarr; <span style="color:#f87171">-$${e.expense_amount.toFixed(2)}</span> ${e.expense_store} (${e.expense_category}) on ${e.expense_date}
+                </div>`
+            ).join('');
+            const alreadySaved = (this.data.reimburserPairs||[]).some(p => p.reimburser_pattern === d.reimburser_pattern && p.expense_pattern === d.expense_pattern);
+            return `<tr>
+                <td>
+                    <div style="font-weight:500">${d.reimburser_pattern} &rarr; ${d.expense_pattern}</div>
+                    <div style="font-size:11px;color:#64748b">${d.link_count} linked transaction${d.link_count>1?'s':''}</div>
+                    ${examples}
+                </td>
+                <td style="vertical-align:top;white-space:nowrap">
+                    ${alreadySaved
+                        ? `<span style="font-size:11px;color:#4ade80">&#x2713; Saved</span>`
+                        : `<button class="btn btn-sm btn-success" onclick="App.acceptDiscovered(${i})">Save rule</button>`}
+                </td>
+            </tr>`;
+        }).join('');
         document.getElementById('discoveredPairs').classList.remove('hidden');
     },
 
@@ -1464,10 +1565,22 @@ const App = {
 
     renderRecycleBin() {
         const body = document.getElementById('recycleBody');
-        body.innerHTML = this.data.deleted.map(t =>
-            `<tr><td>${t.date}</td><td>${t.store_normalized}</td><td>$${t.amount.toFixed(2)}</td>
-             <td><button class="btn btn-sm" onclick="App.restoreTxn('${t.uuid}')">Restore</button></td></tr>`
-        ).join('');
+        body.innerHTML = this.data.deleted.map(t => {
+            const linkedInfo = t.linked_to
+                ? `<span style="font-size:11px;color:#f59e0b" title="Has linked reimbursement — restoring won't restore the link">&#x26A0; was linked</span>`
+                : '';
+            const deletedWhen = t.deleted_at ? `<span style="font-size:11px;color:#64748b">deleted ${t.deleted_at}</span>` : '';
+            return `<tr>
+                <td>${t.date}</td>
+                <td>
+                    <div>${t.store_normalized}</div>
+                    <div style="font-size:11px;color:#64748b">${t.category || 'Uncategorized'} · ${t.source_file}</div>
+                </td>
+                <td style="color:#f87171">-$${t.amount.toFixed(2)}</td>
+                <td>${deletedWhen} ${linkedInfo}</td>
+                <td><button class="btn btn-sm" onclick="App.restoreTxn('${t.uuid}')">Restore</button></td>
+            </tr>`;
+        }).join('');
     },
 
     async restoreTxn(uuid) {
@@ -1507,30 +1620,65 @@ const App = {
         const sec = document.getElementById('tripDetailSection');
         document.getElementById('tripDetailName').textContent = data.trip.name;
         document.getElementById('tripDetailDates').textContent = `${data.trip.start_date} – ${data.trip.end_date}`;
+
+        // Render excluded category checkboxes for this trip
+        const cats = this.data.summary.categories || [];
+        const excluded = data.trip.excluded_categories || [];
+        const excludedSet = new Set(excluded);
+        const excContainer = document.getElementById('tripExcludedCats');
+        if (excContainer) {
+            excContainer.innerHTML = cats.map(c =>
+                `<label style="font-size:12px;color:#cbd5e1"><input type="checkbox" value="${c}" ${excludedSet.has(c)?'checked':''}> ${c}</label>`
+            ).join(' ');
+        }
+        document.getElementById('saveTripExclusionsBtn').onclick = () => App.saveTripExclusions(tripId);
+
         const txns = data.transactions || [];
-        const total = txns.filter(t => t.type === 'expense').reduce((s, t) => s + t.amount, 0);
-        document.getElementById('tripDetailTotal').textContent = `Total: $${total.toFixed(2)}`;
-        this._renderTripSplit(total);
+        this._renderTripSplit(txns);
         document.getElementById('tripTxnBody').innerHTML = txns.map(t =>
-            `<tr>
+            `<tr${t.is_solo ? ' style="background:#1e2d1e"' : ''}>
                 <td>${t.date}</td>
                 <td>${t.store_normalized||t.store_raw}</td>
                 <td>${catBadge(t.category)}</td>
-                <td style="color:${t.type==='income'?'#4ade80':'#f87171'}">${t.type==='income'?'+':'-'}$${t.amount.toFixed(2)}</td>
-                <td><button class="btn btn-sm btn-danger" onclick="App.removeTripTxn(${tripId},'${t.uuid}')">Remove</button></td>
+                <td style="color:#f87171">-$${t.amount.toFixed(2)}</td>
+                <td style="white-space:nowrap">
+                    <button class="btn btn-sm ${t.is_solo?'btn-success':'btn-outline'}" title="${t.is_solo?'Just you — click to split':'Split — click to mark as just you'}" onclick="App.toggleTripSolo(${tripId},'${t.uuid}')">
+                        ${t.is_solo ? '&#x1F464; Just me' : '&#x1F465; Split'}
+                    </button>
+                    <button class="btn btn-sm btn-danger" onclick="App.removeTripTxn(${tripId},'${t.uuid}')">Remove</button>
+                </td>
             </tr>`
         ).join('');
         sec.classList.remove('hidden');
         document.getElementById('tripSplitPct').oninput = () => {
-            const total2 = (this._currentTrip?.transactions||[]).filter(t=>t.type==='expense').reduce((s,t)=>s+t.amount,0);
-            this._renderTripSplit(total2);
+            this._renderTripSplit(this._currentTrip?.transactions || []);
         };
     },
 
-    _renderTripSplit(total) {
+    async saveTripExclusions(tripId) {
+        const excluded = [...document.querySelectorAll('#tripExcludedCats input:checked')].map(el => el.value);
+        const trip = this._currentTrip?.trip;
+        if (!trip) return;
+        await apiPost(`/api/trips/${tripId}`, {
+            name: trip.name, start_date: trip.start_date,
+            end_date: trip.end_date, notes: trip.notes || '',
+            excluded_categories: excluded,
+        });
+        toast(`Exclusions saved. Reloading trip...`);
+        await this.openTrip(tripId);
+        const d = await api('/api/trips');
+        this.data.trips = d.trips || [];
+        this.renderTrips();
+    },
+
+    _renderTripSplit(txns) {
         const pct = parseFloat(document.getElementById('tripSplitPct').value) || 60;
-        const mine = total * pct / 100;
-        const theirs = total - mine;
+        const total = txns.reduce((s, t) => s + t.amount, 0);
+        const soloTotal = txns.filter(t => t.is_solo).reduce((s, t) => s + t.amount, 0);
+        const splitTotal = txns.filter(t => !t.is_solo).reduce((s, t) => s + t.amount, 0);
+        const mine = soloTotal + splitTotal * pct / 100;
+        const theirs = splitTotal * (1 - pct / 100);
+        document.getElementById('tripDetailTotal').textContent = `Total: $${total.toFixed(2)}`;
         document.getElementById('tripSplitResult').textContent =
             `You: $${mine.toFixed(2)} · Partner: $${theirs.toFixed(2)}`;
     },
@@ -1544,6 +1692,11 @@ const App = {
         await api(`/api/trips/${tripId}`, {method:'DELETE'});
         toast('Trip deleted');
         await this.refresh();
+    },
+
+    async toggleTripSolo(tripId, txnUuid) {
+        await apiPost(`/api/trips/${tripId}/transactions/${txnUuid}/toggle-solo`, {});
+        await this.openTrip(tripId);
     },
 
     async removeTripTxn(tripId, txnUuid) {
@@ -1649,7 +1802,12 @@ const App = {
             const tripNames = (this.data.trips||[]).filter(trip => {
                 return trip.start_date <= t.date && t.date <= trip.end_date;
             }).map(trip => `<span style="font-size:11px;background:#1e3a5f;color:#93c5fd;padding:1px 6px;border-radius:4px;cursor:pointer" onclick="App.openTrip(${trip.id})">${trip.name}</span>`).join(' ');
-            return `<tr${hasOffset ? ' style="background:#fefce8"' : ''}>
+            const isTransfer = t.type === 'transfer';
+            const transferBtn = t.type !== 'income'
+                ? `<button class="btn btn-sm btn-outline" style="${isTransfer?'color:#a78bfa':'color:#64748b'}" title="${isTransfer?'Mark as expense':'Mark as transfer (exclude from totals)'}" onclick="App.toggleTransfer('${t.uuid}','${t.type}')">${isTransfer?'Xfr&#x2713;':'Xfr'}</button>`
+                : '';
+            const rowBg = isTransfer ? ' style="opacity:0.5"' : hasOffset ? ' style="background:#1c2a1a"' : '';
+            return `<tr${rowBg}>
                 <td><input type="checkbox" data-uuid="${t.uuid}" ${checked} onchange="App.toggleSelect('${t.uuid}', this.checked)"></td>
                 <td>${t.date}</td>
                 <td title="${t.store_raw}">${t.store_normalized}</td>
@@ -1657,7 +1815,7 @@ const App = {
                 <td style="text-align:right;font-variant-numeric:tabular-nums">${t.type==='income'?'+':'-'}${amtDisplay}</td>
                 <td>${t.type}</td>
                 <td>${tripNames}</td>
-                <td style="display:flex;gap:4px">${linkBtn}<button class="btn btn-sm btn-danger" onclick="App.deleteTxn('${t.uuid}')">Del</button></td>
+                <td style="display:flex;gap:4px">${transferBtn}${linkBtn}<button class="btn btn-sm btn-danger" onclick="App.deleteTxn('${t.uuid}')">Del</button></td>
             </tr>`;
         }).join('');
         document.getElementById('selectAll').checked = false;
@@ -1713,6 +1871,13 @@ const App = {
         if (!category) return;
         await api(`/api/transactions/${uuid}/category`, {method:'PATCH', headers:{'Content-Type':'application/json'}, body:JSON.stringify({category})});
         toast(`Updated category to ${category}`);
+        await this.refresh();
+    },
+
+    async toggleTransfer(uuid, currentType) {
+        const newType = currentType === 'transfer' ? 'expense' : 'transfer';
+        await api(`/api/transactions/${uuid}/type`, {method:'PATCH', headers:{'Content-Type':'application/json'}, body:JSON.stringify({type: newType})});
+        toast(newType === 'transfer' ? 'Marked as transfer — excluded from totals' : 'Marked as expense');
         await this.refresh();
     },
 
@@ -1914,7 +2079,8 @@ document.getElementById('createTripBtn').addEventListener('click', async () => {
     const end = document.getElementById('newTripEnd').value;
     const notes = document.getElementById('newTripNotes').value.trim();
     if (!name || !start || !end) { toast('Name, start and end date required'); return; }
-    const r = await apiPost('/api/trips', {name, start_date: start, end_date: end, notes, auto_assign: true});
+    const excluded = [...document.querySelectorAll('#newTripExcludedCats input:checked')].map(el => el.value);
+    const r = await apiPost('/api/trips', {name, start_date: start, end_date: end, notes, auto_assign: true, excluded_categories: excluded});
     toast(`Trip created, ${r.assigned} transactions assigned`);
     document.getElementById('newTripName').value = '';
     document.getElementById('newTripNotes').value = '';

--- a/smtm/db.py
+++ b/smtm/db.py
@@ -9,7 +9,20 @@ from pathlib import Path
 
 from .models import CategoryDB, Transaction, TxnType
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 5
+
+_MIGRATIONS = [
+    # 1: linked reimbursements
+    "ALTER TABLE transactions ADD COLUMN linked_to TEXT DEFAULT ''",
+    # 2: expense adjustment (partial offset amount)
+    "ALTER TABLE transactions ADD COLUMN adjustment REAL DEFAULT 0.0",
+    # 3: per-trip category exclusions
+    "ALTER TABLE trips ADD COLUMN excluded_categories TEXT DEFAULT '[\"Investments\"]'",
+    # 4: per-transaction solo flag (100% owner, not split)
+    "ALTER TABLE trip_transactions ADD COLUMN is_solo INTEGER DEFAULT 0",
+    # 5: soft-delete timestamp
+    "ALTER TABLE transactions ADD COLUMN deleted_at TEXT DEFAULT ''",
+]
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS transactions (
@@ -27,6 +40,7 @@ CREATE TABLE IF NOT EXISTS transactions (
     is_deleted INTEGER DEFAULT 0,
     linked_to TEXT DEFAULT '',
     adjustment REAL DEFAULT 0.0,
+    deleted_at TEXT DEFAULT '',
     created_at TEXT DEFAULT (datetime('now'))
 );
 
@@ -92,12 +106,14 @@ CREATE TABLE IF NOT EXISTS trips (
     start_date TEXT NOT NULL,
     end_date TEXT NOT NULL,
     notes TEXT DEFAULT '',
+    excluded_categories TEXT DEFAULT '["Investments"]',
     created_at TEXT DEFAULT (datetime('now'))
 );
 
 CREATE TABLE IF NOT EXISTS trip_transactions (
     trip_id INTEGER NOT NULL,
     txn_uuid TEXT NOT NULL,
+    is_solo INTEGER DEFAULT 0,
     PRIMARY KEY (trip_id, txn_uuid),
     FOREIGN KEY (trip_id) REFERENCES trips(id) ON DELETE CASCADE,
     FOREIGN KEY (txn_uuid) REFERENCES transactions(uuid) ON DELETE CASCADE
@@ -148,19 +164,19 @@ class Database:
             self._migrate()
 
     def _migrate(self):
-        cols = {
-            r[1]
-            for r in self.conn.execute("PRAGMA table_info(transactions)").fetchall()
-        }
+        row = self.conn.execute("SELECT version FROM schema_version").fetchone()
+        ver = row["version"] if row else 0
         with self.conn:
-            if "linked_to" not in cols:
-                self.conn.execute(
-                    "ALTER TABLE transactions ADD COLUMN linked_to TEXT DEFAULT ''"
-                )
-            if "adjustment" not in cols:
-                self.conn.execute(
-                    "ALTER TABLE transactions ADD COLUMN adjustment REAL DEFAULT 0.0"
-                )
+            for i, sql in enumerate(_MIGRATIONS, start=1):
+                if ver < i:
+                    try:
+                        self.conn.execute(sql)
+                    except sqlite3.OperationalError:
+                        pass  # column already exists — idempotent
+                    self.conn.execute(
+                        "UPDATE schema_version SET version = ?", (i,)
+                    )
+                    ver = i
 
     # -- Import log --
 
@@ -254,17 +270,18 @@ class Database:
             return [self._row_to_txn(r) for r in self.conn.execute(sql).fetchall()]
 
     def soft_delete(self, uuid: str) -> bool:
+        from datetime import datetime
         with self.conn:
             cursor = self.conn.execute(
-                "UPDATE transactions SET is_deleted = 1 WHERE uuid = ?",
-                (uuid,),
+                "UPDATE transactions SET is_deleted = 1, deleted_at = ? WHERE uuid = ?",
+                (datetime.now().strftime("%Y-%m-%d %H:%M"), uuid),
             )
         return cursor.rowcount > 0
 
     def restore(self, uuid: str) -> bool:
         with self.conn:
             cursor = self.conn.execute(
-                "UPDATE transactions SET is_deleted = 0 WHERE uuid = ?",
+                "UPDATE transactions SET is_deleted = 0, deleted_at = '' WHERE uuid = ?",
                 (uuid,),
             )
         return cursor.rowcount > 0
@@ -275,6 +292,13 @@ class Database:
                 "UPDATE transactions SET category = ?, confidence = ? "
                 "WHERE uuid = ?",
                 (category, confidence, uuid),
+            )
+
+    def update_txn_type(self, uuid: str, txn_type: str):
+        with self.conn:
+            self.conn.execute(
+                "UPDATE transactions SET txn_type = ? WHERE uuid = ?",
+                (txn_type, uuid),
             )
 
     def recategorize_all(self, category_db: CategoryDB):
@@ -354,7 +378,29 @@ class Database:
             rows = self.conn.execute(
                 "SELECT * FROM category_rules ORDER BY priority DESC, pattern"
             ).fetchall()
-            return [dict(r) for r in rows]
+            rules = [dict(r) for r in rows]
+            store_counts: dict[str, int] = {}
+            for r in self.conn.execute(
+                "SELECT LOWER(store_normalized) as sn, COUNT(*) as cnt "
+                "FROM transactions WHERE is_deleted=0 GROUP BY sn"
+            ).fetchall():
+                store_counts[r["sn"]] = r["cnt"]
+        raw_counts: dict[str, int] = {}
+        for r in self.conn.execute(
+            "SELECT LOWER(store_raw) as k, COUNT(*) as cnt "
+            "FROM transactions WHERE is_deleted=0 GROUP BY k"
+        ).fetchall():
+            raw_counts[r["k"]] = r["cnt"]
+        for rule in rules:
+            p = rule["pattern"].lower()
+            mt = rule["match_type"]
+            if mt == "exact":
+                rule["txn_count"] = store_counts.get(p, 0) or raw_counts.get(p, 0)
+            else:
+                rule["txn_count"] = sum(
+                    cnt for sn, cnt in store_counts.items() if p in sn
+                ) or sum(cnt for sr, cnt in raw_counts.items() if p in sr)
+        return rules
 
     def add_category_rule(
         self, pattern: str, category: str, match_type: str = "exact", priority: int = 0
@@ -667,38 +713,52 @@ class Database:
     def discover_reimburser_pairs(self) -> list[dict]:
         """Scan historical links to discover reimburser-to-expense patterns."""
         with self._lock:
-            # Find expenses that have been linked (have linked_to set)
             rows = self.conn.execute(
-                "SELECT store_normalized, store_raw, linked_to FROM transactions "
-                "WHERE linked_to != '' AND txn_type = 'expense' AND adjustment > 0"
+                "SELECT e.uuid as exp_uuid, e.store_normalized as exp_norm, e.store_raw as exp_raw, "
+                "e.amount as exp_amount, e.date as exp_date, e.category as exp_cat, "
+                "e.linked_to as inc_uuid "
+                "FROM transactions e "
+                "WHERE e.linked_to != '' AND e.txn_type = 'expense' AND e.adjustment > 0"
             ).fetchall()
         if not rows:
             return []
-        # For each linked expense, find the income it was linked to
-        pair_counts: dict[tuple[str, str], int] = {}
+
+        pair_data: dict[tuple[str, str], dict] = {}
         for row in rows:
-            expense_store = (row["store_normalized"] or row["store_raw"]).lower()
-            income_uuid = row["linked_to"]
+            expense_store = (row["exp_norm"] or row["exp_raw"]).lower()
             with self._lock:
                 inc_row = self.conn.execute(
-                    "SELECT store_normalized, store_raw FROM transactions "
-                    "WHERE uuid = ?",
-                    (income_uuid,),
+                    "SELECT store_normalized, store_raw, amount, date FROM transactions WHERE uuid = ?",
+                    (row["inc_uuid"],),
                 ).fetchone()
-            if inc_row:
-                income_store = (
-                    inc_row["store_normalized"] or inc_row["store_raw"]
-                ).lower()
-                key = (income_store, expense_store)
-                pair_counts[key] = pair_counts.get(key, 0) + 1
-        # Return pairs sorted by frequency
+            if not inc_row:
+                continue
+            income_store = (inc_row["store_normalized"] or inc_row["store_raw"]).lower()
+            if income_store == expense_store:
+                continue  # refund to same store — not a meaningful pair
+            key = (income_store, expense_store)
+            if key not in pair_data:
+                pair_data[key] = {"link_count": 0, "examples": []}
+            pair_data[key]["link_count"] += 1
+            if len(pair_data[key]["examples"]) < 3:
+                pair_data[key]["examples"].append({
+                    "income_date": inc_row["date"],
+                    "income_store": inc_row["store_normalized"] or inc_row["store_raw"],
+                    "income_amount": round(inc_row["amount"], 2),
+                    "expense_date": row["exp_date"],
+                    "expense_store": row["exp_norm"] or row["exp_raw"],
+                    "expense_amount": round(row["exp_amount"], 2),
+                    "expense_category": row["exp_cat"] or "",
+                })
+
         discovered = [
             {
                 "reimburser_pattern": k[0],
                 "expense_pattern": k[1],
-                "link_count": v,
+                "link_count": v["link_count"],
+                "examples": v["examples"],
             }
-            for k, v in pair_counts.items()
+            for k, v in pair_data.items()
         ]
         discovered.sort(key=lambda x: x["link_count"], reverse=True)
         return discovered
@@ -903,44 +963,125 @@ class Database:
     # -- Trips --
 
     def get_trips(self) -> list[dict]:
+        from collections import defaultdict
+
         with self._lock:
-            rows = self.conn.execute(
-                "SELECT t.id, t.name, t.start_date, t.end_date, t.notes, "
-                "COUNT(tt.txn_uuid) AS txn_count, "
-                "COALESCE(SUM(CASE WHEN tr.txn_type='expense' THEN tr.amount ELSE 0 END), 0) AS total_spend "
-                "FROM trips t "
-                "LEFT JOIN trip_transactions tt ON tt.trip_id = t.id "
-                "LEFT JOIN transactions tr ON tr.uuid = tt.txn_uuid AND tr.is_deleted = 0 "
-                "GROUP BY t.id ORDER BY t.start_date DESC"
+            trip_rows = self.conn.execute(
+                "SELECT id, name, start_date, end_date, notes, excluded_categories "
+                "FROM trips ORDER BY start_date DESC"
             ).fetchall()
-        return [dict(r) for r in rows]
+            txn_rows = self.conn.execute(
+                "SELECT tt.trip_id, tr.amount, tr.category "
+                "FROM trip_transactions tt "
+                "JOIN transactions tr ON tr.uuid = tt.txn_uuid "
+                "WHERE tr.is_deleted = 0 AND tr.txn_type = 'expense'"
+            ).fetchall()
+
+        txns_by_trip: dict[int, list] = defaultdict(list)
+        for r in txn_rows:
+            txns_by_trip[r["trip_id"]].append(r)
+
+        result = []
+        for t in trip_rows:
+            excluded = set(
+                c.lower() for c in json.loads(t["excluded_categories"] or "[]")
+            )
+            included = [
+                r
+                for r in txns_by_trip[t["id"]]
+                if (r["category"] or "").lower() not in excluded
+            ]
+            result.append(
+                {
+                    "id": t["id"],
+                    "name": t["name"],
+                    "start_date": t["start_date"],
+                    "end_date": t["end_date"],
+                    "notes": t["notes"],
+                    "excluded_categories": json.loads(
+                        t["excluded_categories"] or "[]"
+                    ),
+                    "txn_count": len(included),
+                    "total_spend": round(sum(r["amount"] for r in included), 2),
+                }
+            )
+        return result
 
     def get_trip(self, trip_id: int) -> dict | None:
         with self._lock:
             row = self.conn.execute(
-                "SELECT t.id, t.name, t.start_date, t.end_date, t.notes "
-                "FROM trips t WHERE t.id = ?",
+                "SELECT id, name, start_date, end_date, notes, excluded_categories "
+                "FROM trips WHERE id = ?",
                 (trip_id,),
             ).fetchone()
-        return dict(row) if row else None
+        if not row:
+            return None
+        d = dict(row)
+        d["excluded_categories"] = json.loads(d["excluded_categories"] or "[]")
+        return d
 
-    def get_trip_transactions(self, trip_id: int) -> list[Transaction]:
+    def get_trip_transactions(self, trip_id: int) -> list[dict]:
+        """Return trip transactions as dicts including is_solo flag."""
+        trip = self.get_trip(trip_id)
+        excluded = set(
+            c.lower() for c in ((trip or {}).get("excluded_categories") or [])
+        )
         with self._lock:
             rows = self.conn.execute(
-                "SELECT tr.* FROM transactions tr "
+                "SELECT tr.*, tt.is_solo FROM transactions tr "
                 "JOIN trip_transactions tt ON tt.txn_uuid = tr.uuid "
-                "WHERE tt.trip_id = ? AND tr.is_deleted = 0 ORDER BY tr.date",
+                "WHERE tt.trip_id = ? AND tr.is_deleted = 0 AND tr.txn_type = 'expense' ORDER BY tr.date",
                 (trip_id,),
             ).fetchall()
-        return [self._row_to_txn(r) for r in rows]
+        result = []
+        for r in rows:
+            if (r["category"] or "").lower() in excluded:
+                continue
+            txn = self._row_to_txn(r)
+            d = {
+                "date": txn.date.isoformat(),
+                "month": txn.month,
+                "amount": round(txn.amount, 2),
+                "store_raw": txn.store_raw,
+                "store_normalized": txn.store_normalized or txn.store_raw,
+                "category": txn.category or "Uncategorized",
+                "type": txn.txn_type.value,
+                "uuid": txn.uuid,
+                "is_solo": bool(r["is_solo"]),
+            }
+            result.append(d)
+        return result
+
+    def toggle_trip_solo(self, trip_id: int, txn_uuid: str) -> bool:
+        with self._lock:
+            row = self.conn.execute(
+                "SELECT is_solo FROM trip_transactions WHERE trip_id = ? AND txn_uuid = ?",
+                (trip_id, txn_uuid),
+            ).fetchone()
+        if not row:
+            return False
+        new_val = 0 if row["is_solo"] else 1
+        with self.conn:
+            self.conn.execute(
+                "UPDATE trip_transactions SET is_solo = ? WHERE trip_id = ? AND txn_uuid = ?",
+                (new_val, trip_id, txn_uuid),
+            )
+        return True
 
     def create_trip(
-        self, name: str, start_date: str, end_date: str, notes: str = ""
+        self,
+        name: str,
+        start_date: str,
+        end_date: str,
+        notes: str = "",
+        excluded_categories: list[str] | None = None,
     ) -> int:
+        if excluded_categories is None:
+            excluded_categories = ["Investments"]
         with self.conn:
             cur = self.conn.execute(
-                "INSERT INTO trips (name, start_date, end_date, notes) VALUES (?, ?, ?, ?)",
-                (name, start_date, end_date, notes),
+                "INSERT INTO trips (name, start_date, end_date, notes, excluded_categories) VALUES (?, ?, ?, ?, ?)",
+                (name, start_date, end_date, notes, json.dumps(excluded_categories)),
             )
         return cur.lastrowid
 
@@ -953,11 +1094,15 @@ class Database:
         trip = self.get_trip(trip_id)
         if not trip:
             return 0
+        excluded = set(
+            c.lower() for c in (trip.get("excluded_categories") or [])
+        )
         with self._lock:
             rows = self.conn.execute(
-                "SELECT uuid FROM transactions WHERE date >= ? AND date <= ? AND is_deleted = 0",
+                "SELECT uuid, category FROM transactions WHERE date >= ? AND date <= ? AND is_deleted = 0 AND txn_type = 'expense'",
                 (trip["start_date"], trip["end_date"]),
             ).fetchall()
+        rows = [r for r in rows if (r["category"] or "").lower() not in excluded]
         added = 0
         with self.conn:
             for row in rows:
@@ -991,12 +1136,23 @@ class Database:
         return cur.rowcount > 0
 
     def update_trip(
-        self, trip_id: int, name: str, start_date: str, end_date: str, notes: str = ""
+        self,
+        trip_id: int,
+        name: str,
+        start_date: str,
+        end_date: str,
+        notes: str = "",
+        excluded_categories: list[str] | None = None,
     ) -> bool:
+        fields = "name=?, start_date=?, end_date=?, notes=?"
+        params: list = [name, start_date, end_date, notes]
+        if excluded_categories is not None:
+            fields += ", excluded_categories=?"
+            params.append(json.dumps(excluded_categories))
+        params.append(trip_id)
         with self.conn:
             cur = self.conn.execute(
-                "UPDATE trips SET name=?, start_date=?, end_date=?, notes=? WHERE id=?",
-                (name, start_date, end_date, notes, trip_id),
+                f"UPDATE trips SET {fields} WHERE id=?", params
             )
         return cur.rowcount > 0
 
@@ -1018,6 +1174,7 @@ class Database:
             is_deleted=bool(row["is_deleted"]),
             linked_to=row["linked_to"] or "",
             adjustment=row["adjustment"] or 0.0,
+            deleted_at=row["deleted_at"] if "deleted_at" in row.keys() else "",
         )
 
     @staticmethod

--- a/smtm/db.py
+++ b/smtm/db.py
@@ -86,6 +86,23 @@ CREATE TABLE IF NOT EXISTS import_log (
 
 CREATE INDEX IF NOT EXISTS idx_import_hash ON import_log(file_hash);
 
+CREATE TABLE IF NOT EXISTS trips (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    start_date TEXT NOT NULL,
+    end_date TEXT NOT NULL,
+    notes TEXT DEFAULT '',
+    created_at TEXT DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS trip_transactions (
+    trip_id INTEGER NOT NULL,
+    txn_uuid TEXT NOT NULL,
+    PRIMARY KEY (trip_id, txn_uuid),
+    FOREIGN KEY (trip_id) REFERENCES trips(id) ON DELETE CASCADE,
+    FOREIGN KEY (txn_uuid) REFERENCES transactions(uuid) ON DELETE CASCADE
+);
+
 CREATE TABLE IF NOT EXISTS schema_version (
     version INTEGER PRIMARY KEY
 );
@@ -882,6 +899,106 @@ class Database:
                 (income_uuid,),
             )
         return True
+
+    # -- Trips --
+
+    def get_trips(self) -> list[dict]:
+        with self._lock:
+            rows = self.conn.execute(
+                "SELECT t.id, t.name, t.start_date, t.end_date, t.notes, "
+                "COUNT(tt.txn_uuid) AS txn_count, "
+                "COALESCE(SUM(CASE WHEN tr.txn_type='expense' THEN tr.amount ELSE 0 END), 0) AS total_spend "
+                "FROM trips t "
+                "LEFT JOIN trip_transactions tt ON tt.trip_id = t.id "
+                "LEFT JOIN transactions tr ON tr.uuid = tt.txn_uuid AND tr.is_deleted = 0 "
+                "GROUP BY t.id ORDER BY t.start_date DESC"
+            ).fetchall()
+        return [dict(r) for r in rows]
+
+    def get_trip(self, trip_id: int) -> dict | None:
+        with self._lock:
+            row = self.conn.execute(
+                "SELECT t.id, t.name, t.start_date, t.end_date, t.notes "
+                "FROM trips t WHERE t.id = ?",
+                (trip_id,),
+            ).fetchone()
+        return dict(row) if row else None
+
+    def get_trip_transactions(self, trip_id: int) -> list[Transaction]:
+        with self._lock:
+            rows = self.conn.execute(
+                "SELECT tr.* FROM transactions tr "
+                "JOIN trip_transactions tt ON tt.txn_uuid = tr.uuid "
+                "WHERE tt.trip_id = ? AND tr.is_deleted = 0 ORDER BY tr.date",
+                (trip_id,),
+            ).fetchall()
+        return [self._row_to_txn(r) for r in rows]
+
+    def create_trip(
+        self, name: str, start_date: str, end_date: str, notes: str = ""
+    ) -> int:
+        with self.conn:
+            cur = self.conn.execute(
+                "INSERT INTO trips (name, start_date, end_date, notes) VALUES (?, ?, ?, ?)",
+                (name, start_date, end_date, notes),
+            )
+        return cur.lastrowid
+
+    def delete_trip(self, trip_id: int) -> bool:
+        with self.conn:
+            cur = self.conn.execute("DELETE FROM trips WHERE id = ?", (trip_id,))
+        return cur.rowcount > 0
+
+    def auto_assign_trip(self, trip_id: int) -> int:
+        trip = self.get_trip(trip_id)
+        if not trip:
+            return 0
+        with self._lock:
+            rows = self.conn.execute(
+                "SELECT uuid FROM transactions WHERE date >= ? AND date <= ? AND is_deleted = 0",
+                (trip["start_date"], trip["end_date"]),
+            ).fetchall()
+        added = 0
+        with self.conn:
+            for row in rows:
+                try:
+                    self.conn.execute(
+                        "INSERT OR IGNORE INTO trip_transactions (trip_id, txn_uuid) VALUES (?, ?)",
+                        (trip_id, row["uuid"]),
+                    )
+                    added += 1
+                except Exception:
+                    pass
+        return added
+
+    def add_trip_transaction(self, trip_id: int, txn_uuid: str) -> bool:
+        try:
+            with self.conn:
+                self.conn.execute(
+                    "INSERT OR IGNORE INTO trip_transactions (trip_id, txn_uuid) VALUES (?, ?)",
+                    (trip_id, txn_uuid),
+                )
+            return True
+        except Exception:
+            return False
+
+    def remove_trip_transaction(self, trip_id: int, txn_uuid: str) -> bool:
+        with self.conn:
+            cur = self.conn.execute(
+                "DELETE FROM trip_transactions WHERE trip_id = ? AND txn_uuid = ?",
+                (trip_id, txn_uuid),
+            )
+        return cur.rowcount > 0
+
+    def update_trip(
+        self, trip_id: int, name: str, start_date: str, end_date: str, notes: str = ""
+    ) -> bool:
+        with self.conn:
+            cur = self.conn.execute(
+                "UPDATE trips SET name=?, start_date=?, end_date=?, notes=? WHERE id=?",
+                (name, start_date, end_date, notes, trip_id),
+            )
+        return cur.rowcount > 0
 
     # -- Helpers --
 

--- a/smtm/db.py
+++ b/smtm/db.py
@@ -173,9 +173,7 @@ class Database:
                         self.conn.execute(sql)
                     except sqlite3.OperationalError:
                         pass  # column already exists — idempotent
-                    self.conn.execute(
-                        "UPDATE schema_version SET version = ?", (i,)
-                    )
+                    self.conn.execute("UPDATE schema_version SET version = ?", (i,))
                     ver = i
 
     # -- Import log --
@@ -271,6 +269,7 @@ class Database:
 
     def soft_delete(self, uuid: str) -> bool:
         from datetime import datetime
+
         with self.conn:
             cursor = self.conn.execute(
                 "UPDATE transactions SET is_deleted = 1, deleted_at = ? WHERE uuid = ?",
@@ -362,6 +361,41 @@ class Database:
                             (final, row["uuid"]),
                         )
                         updated += 1
+        self.normalize_rules()
+        return updated
+
+    def normalize_rules(self) -> int:
+        """Update exact rule patterns from raw store names to their normalized equivalents."""
+        pairs = self.get_store_pairs()
+        if not pairs:
+            return 0
+        pairs_lower = {k.lower(): v for k, v in pairs.items()}
+        rules = self.conn.execute(
+            "SELECT pattern, category FROM category_rules WHERE match_type = 'exact'"
+        ).fetchall()
+        updated = 0
+        with self.conn:
+            for rule in rules:
+                p = rule["pattern"].lower()
+                if p not in pairs_lower:
+                    continue
+                new_pattern = pairs_lower[p]
+                if new_pattern.lower() == p:
+                    continue
+                try:
+                    self.conn.execute(
+                        "UPDATE category_rules SET pattern = ? "
+                        "WHERE pattern = ? AND match_type = 'exact'",
+                        (new_pattern, rule["pattern"]),
+                    )
+                    updated += 1
+                except sqlite3.IntegrityError:
+                    # Normalized pattern already has a rule — drop the raw duplicate
+                    self.conn.execute(
+                        "DELETE FROM category_rules WHERE pattern = ? AND match_type = 'exact'",
+                        (rule["pattern"],),
+                    )
+                    updated += 1
         return updated
 
     def remove_store_pair(self, raw_name: str) -> bool:
@@ -741,15 +775,18 @@ class Database:
                 pair_data[key] = {"link_count": 0, "examples": []}
             pair_data[key]["link_count"] += 1
             if len(pair_data[key]["examples"]) < 3:
-                pair_data[key]["examples"].append({
-                    "income_date": inc_row["date"],
-                    "income_store": inc_row["store_normalized"] or inc_row["store_raw"],
-                    "income_amount": round(inc_row["amount"], 2),
-                    "expense_date": row["exp_date"],
-                    "expense_store": row["exp_norm"] or row["exp_raw"],
-                    "expense_amount": round(row["exp_amount"], 2),
-                    "expense_category": row["exp_cat"] or "",
-                })
+                pair_data[key]["examples"].append(
+                    {
+                        "income_date": inc_row["date"],
+                        "income_store": inc_row["store_normalized"]
+                        or inc_row["store_raw"],
+                        "income_amount": round(inc_row["amount"], 2),
+                        "expense_date": row["exp_date"],
+                        "expense_store": row["exp_norm"] or row["exp_raw"],
+                        "expense_amount": round(row["exp_amount"], 2),
+                        "expense_category": row["exp_cat"] or "",
+                    }
+                )
 
         discovered = [
             {
@@ -998,9 +1035,7 @@ class Database:
                     "start_date": t["start_date"],
                     "end_date": t["end_date"],
                     "notes": t["notes"],
-                    "excluded_categories": json.loads(
-                        t["excluded_categories"] or "[]"
-                    ),
+                    "excluded_categories": json.loads(t["excluded_categories"] or "[]"),
                     "txn_count": len(included),
                     "total_spend": round(sum(r["amount"] for r in included), 2),
                 }
@@ -1094,9 +1129,7 @@ class Database:
         trip = self.get_trip(trip_id)
         if not trip:
             return 0
-        excluded = set(
-            c.lower() for c in (trip.get("excluded_categories") or [])
-        )
+        excluded = set(c.lower() for c in (trip.get("excluded_categories") or []))
         with self._lock:
             rows = self.conn.execute(
                 "SELECT uuid, category FROM transactions WHERE date >= ? AND date <= ? AND is_deleted = 0 AND txn_type = 'expense'",
@@ -1151,9 +1184,7 @@ class Database:
             params.append(json.dumps(excluded_categories))
         params.append(trip_id)
         with self.conn:
-            cur = self.conn.execute(
-                f"UPDATE trips SET {fields} WHERE id=?", params
-            )
+            cur = self.conn.execute(f"UPDATE trips SET {fields} WHERE id=?", params)
         return cur.rowcount > 0
 
     # -- Helpers --

--- a/smtm/models.py
+++ b/smtm/models.py
@@ -9,6 +9,7 @@ from uuid import uuid4
 class TxnType(Enum):
     EXPENSE = "expense"
     INCOME = "income"
+    TRANSFER = "transfer"
 
 
 @dataclass
@@ -26,6 +27,7 @@ class Transaction:
     is_deleted: bool = False
     linked_to: str = ""
     adjustment: float = 0.0
+    deleted_at: str = ""
 
     def __post_init__(self):
         if not self.uuid:

--- a/smtm/server.py
+++ b/smtm/server.py
@@ -525,6 +525,9 @@ class Handler(BaseHTTPRequestHandler):
             self._handle_import(preview=False)
         elif path == "/api/import/preview":
             self._handle_import(preview=True)
+        elif path == "/api/rules/normalize":
+            normalized = self.db.normalize_rules()
+            self._json_response({"ok": True, "normalized": normalized})
         elif path == "/api/rules":
             data = self._read_json_body()
             pattern = data.get("pattern", "")
@@ -702,7 +705,9 @@ class Handler(BaseHTTPRequestHandler):
             end_date = data.get("end_date", "")
             notes = data.get("notes", "")
             excluded = data.get("excluded_categories", None)
-            if self.db.update_trip(trip_id, name, start_date, end_date, notes, excluded):
+            if self.db.update_trip(
+                trip_id, name, start_date, end_date, notes, excluded
+            ):
                 self._json_response({"ok": True})
             else:
                 self._error(404, "Trip not found")

--- a/smtm/server.py
+++ b/smtm/server.py
@@ -2,6 +2,7 @@
 
 import json
 import math
+import re
 import tempfile
 import threading
 from collections import Counter, defaultdict
@@ -501,6 +502,16 @@ class Handler(BaseHTTPRequestHandler):
             self._json_response({"pairs": self.db.get_reimburser_pairs()})
         elif path == "/api/reimburser-pairs/discover":
             self._json_response({"discovered": self.db.discover_reimburser_pairs()})
+        elif path == "/api/trips":
+            self._json_response({"trips": self.db.get_trips()})
+        elif re.match(r"^/api/trips/(\d+)$", path):
+            trip_id = int(re.match(r"^/api/trips/(\d+)$", path).group(1))
+            trip = self.db.get_trip(trip_id)
+            if not trip:
+                self._error(404, "Trip not found")
+            else:
+                txns = self.db.get_trip_transactions(trip_id)
+                self._json_response({"trip": trip, "transactions": _txns_to_json(txns)})
         elif path == "/api/report/pdf":
             self._handle_pdf_download()
         else:
@@ -647,6 +658,45 @@ class Handler(BaseHTTPRequestHandler):
                 self._json_response({"ok": True})
             else:
                 self._error(404, "Transaction not found or not linked")
+        elif path == "/api/trips":
+            data = self._read_json_body()
+            name = data.get("name", "").strip()
+            start_date = data.get("start_date", "")
+            end_date = data.get("end_date", "")
+            notes = data.get("notes", "")
+            if not name or not start_date or not end_date:
+                self._error(400, "name, start_date, end_date required")
+                return
+            trip_id = self.db.create_trip(name, start_date, end_date, notes)
+            if data.get("auto_assign"):
+                added = self.db.auto_assign_trip(trip_id)
+            else:
+                added = 0
+            self._json_response({"ok": True, "id": trip_id, "assigned": added})
+        elif re.match(r"^/api/trips/(\d+)/auto-assign$", path):
+            trip_id = int(re.match(r"^/api/trips/(\d+)/auto-assign$", path).group(1))
+            added = self.db.auto_assign_trip(trip_id)
+            self._json_response({"ok": True, "assigned": added})
+        elif re.match(r"^/api/trips/(\d+)/transactions$", path):
+            trip_id = int(re.match(r"^/api/trips/(\d+)/transactions$", path).group(1))
+            data = self._read_json_body()
+            txn_uuid = data.get("uuid", "")
+            if not txn_uuid:
+                self._error(400, "uuid required")
+                return
+            self.db.add_trip_transaction(trip_id, txn_uuid)
+            self._json_response({"ok": True})
+        elif re.match(r"^/api/trips/(\d+)$", path):
+            trip_id = int(re.match(r"^/api/trips/(\d+)$", path).group(1))
+            data = self._read_json_body()
+            name = data.get("name", "").strip()
+            start_date = data.get("start_date", "")
+            end_date = data.get("end_date", "")
+            notes = data.get("notes", "")
+            if self.db.update_trip(trip_id, name, start_date, end_date, notes):
+                self._json_response({"ok": True})
+            else:
+                self._error(404, "Trip not found")
         else:
             self._error(404, "Not found")
 
@@ -687,6 +737,17 @@ class Handler(BaseHTTPRequestHandler):
                 self._json_response({"ok": True})
             else:
                 self._error(404, "Transaction not found")
+        elif re.match(r"^/api/trips/(\d+)/transactions/(.+)$", path):
+            m = re.match(r"^/api/trips/(\d+)/transactions/(.+)$", path)
+            trip_id, txn_uuid = int(m.group(1)), m.group(2)
+            self.db.remove_trip_transaction(trip_id, txn_uuid)
+            self._json_response({"ok": True})
+        elif re.match(r"^/api/trips/(\d+)$", path):
+            trip_id = int(re.match(r"^/api/trips/(\d+)$", path).group(1))
+            if self.db.delete_trip(trip_id):
+                self._json_response({"ok": True})
+            else:
+                self._error(404, "Trip not found")
         else:
             self._error(404, "Not found")
 

--- a/smtm/server.py
+++ b/smtm/server.py
@@ -511,7 +511,7 @@ class Handler(BaseHTTPRequestHandler):
                 self._error(404, "Trip not found")
             else:
                 txns = self.db.get_trip_transactions(trip_id)
-                self._json_response({"trip": trip, "transactions": _txns_to_json(txns)})
+                self._json_response({"trip": trip, "transactions": txns})
         elif path == "/api/report/pdf":
             self._handle_pdf_download()
         else:
@@ -664,10 +664,11 @@ class Handler(BaseHTTPRequestHandler):
             start_date = data.get("start_date", "")
             end_date = data.get("end_date", "")
             notes = data.get("notes", "")
+            excluded = data.get("excluded_categories", None)
             if not name or not start_date or not end_date:
                 self._error(400, "name, start_date, end_date required")
                 return
-            trip_id = self.db.create_trip(name, start_date, end_date, notes)
+            trip_id = self.db.create_trip(name, start_date, end_date, notes, excluded)
             if data.get("auto_assign"):
                 added = self.db.auto_assign_trip(trip_id)
             else:
@@ -686,6 +687,13 @@ class Handler(BaseHTTPRequestHandler):
                 return
             self.db.add_trip_transaction(trip_id, txn_uuid)
             self._json_response({"ok": True})
+        elif re.match(r"^/api/trips/(\d+)/transactions/[^/]+/toggle-solo$", path):
+            m = re.match(r"^/api/trips/(\d+)/transactions/([^/]+)/toggle-solo$", path)
+            trip_id, txn_uuid = int(m.group(1)), m.group(2)
+            if self.db.toggle_trip_solo(trip_id, txn_uuid):
+                self._json_response({"ok": True})
+            else:
+                self._error(404, "Trip transaction not found")
         elif re.match(r"^/api/trips/(\d+)$", path):
             trip_id = int(re.match(r"^/api/trips/(\d+)$", path).group(1))
             data = self._read_json_body()
@@ -693,7 +701,8 @@ class Handler(BaseHTTPRequestHandler):
             start_date = data.get("start_date", "")
             end_date = data.get("end_date", "")
             notes = data.get("notes", "")
-            if self.db.update_trip(trip_id, name, start_date, end_date, notes):
+            excluded = data.get("excluded_categories", None)
+            if self.db.update_trip(trip_id, name, start_date, end_date, notes, excluded):
                 self._json_response({"ok": True})
             else:
                 self._error(404, "Trip not found")
@@ -714,6 +723,17 @@ class Handler(BaseHTTPRequestHandler):
                 self._error(400, "category required")
                 return
             self.db.update_category(uuid, category)
+            self._json_response({"ok": True})
+        elif path.startswith("/api/transactions/") and "/type" in path:
+            uuid = self._extract_uuid(path, "/api/transactions/")
+            if uuid.endswith("/type"):
+                uuid = uuid[:-5]
+            data = self._read_json_body()
+            txn_type = data.get("type", "")
+            if txn_type not in ("expense", "income", "transfer"):
+                self._error(400, "type must be expense, income, or transfer")
+                return
+            self.db.update_txn_type(uuid, txn_type)
             self._json_response({"ok": True})
         else:
             self._error(404, "Not found")

--- a/tests/e2e/pages.py
+++ b/tests/e2e/pages.py
@@ -160,7 +160,9 @@ class DashboardPage:
     def search_pairs(self, query: str):
         self.page.locator("#pairsSearch").fill(query)
 
-    def add_reimburser(self, pattern: str, label: str = "", match_type: str = "substring"):
+    def add_reimburser(
+        self, pattern: str, label: str = "", match_type: str = "substring"
+    ):
         self.click_tab("reimburse")
         self.page.locator("#newReimburserPattern").fill(pattern)
         if label:

--- a/tests/e2e/pages.py
+++ b/tests/e2e/pages.py
@@ -160,6 +160,23 @@ class DashboardPage:
     def search_pairs(self, query: str):
         self.page.locator("#pairsSearch").fill(query)
 
+    def add_reimburser(self, pattern: str, label: str = "", match_type: str = "substring"):
+        self.click_tab("reimburse")
+        self.page.locator("#newReimburserPattern").fill(pattern)
+        if label:
+            self.page.locator("#newReimburserLabel").fill(label)
+        self.page.locator("#newReimburserType").select_option(match_type)
+        self.page.locator("#addReimburserBtn").click()
+
+    def create_trip(self, name: str, start_date: str, end_date: str, notes: str = ""):
+        self.click_tab("trips")
+        self.page.locator("#newTripName").fill(name)
+        self.page.locator("#newTripStart").fill(start_date)
+        self.page.locator("#newTripEnd").fill(end_date)
+        if notes:
+            self.page.locator("#newTripNotes").fill(notes)
+        self.page.locator("#createTripBtn").click()
+
     def restore_first_deleted(self):
         self.page.locator("#recycleBody .btn").first.click()
 

--- a/tests/e2e/pages.py
+++ b/tests/e2e/pages.py
@@ -40,30 +40,39 @@ class DashboardPage:
     def txn_count_text(self) -> str:
         return self.page.locator("#txnCount").inner_text()
 
+    def go_to_transactions(self):
+        self.click_tab("transactions")
+
     def search_transactions(self, query: str):
+        self.go_to_transactions()
         inp = self.page.locator("#searchInput")
         inp.fill(query)
         expect(self.page.locator("#txnCount")).to_contain_text("Showing")
 
     def filter_category(self, category: str):
+        self.go_to_transactions()
         self.page.locator("#categoryFilter").select_option(category)
         expect(self.page.locator("#txnCount")).to_contain_text("Showing")
 
     def filter_date_range(self, from_date: str, to_date: str):
+        self.go_to_transactions()
         self.page.locator("#dateFrom").fill(from_date)
         self.page.locator("#dateTo").fill(to_date)
         expect(self.page.locator("#txnCount")).to_contain_text("Showing")
 
     def clear_filters(self):
+        self.go_to_transactions()
         self.page.locator("#searchInput").fill("")
         self.page.locator("#categoryFilter").select_option("")
         self.page.locator("#dateFrom").fill("")
         self.page.locator("#dateTo").fill("")
 
     def select_transaction_checkbox(self, index: int):
+        self.go_to_transactions()
         self.txn_body.locator("input[type='checkbox']").nth(index).check()
 
     def select_all(self):
+        self.go_to_transactions()
         self.page.get_by_test_id("select-all").check()
 
     @property
@@ -86,6 +95,7 @@ class DashboardPage:
         )
 
     def delete_row(self, row_index: int):
+        self.go_to_transactions()
         self.txn_body.locator(".btn-danger").nth(row_index).click()
 
     # --- Import ---
@@ -102,7 +112,7 @@ class DashboardPage:
     # --- Categorize ---
 
     def click_recategorize(self):
-        self.click_tab("categorize")
+        self.click_tab("organize")
         self.page.get_by_test_id("recategorize-btn").click()
 
     @property
@@ -132,7 +142,7 @@ class DashboardPage:
     # --- Manage ---
 
     def add_rule(self, pattern: str, category: str, match_type: str = "exact"):
-        self.click_tab("manage")
+        self.click_tab("organize")
         self.page.locator("#newRulePattern").fill(pattern)
         self.page.locator("#newRuleCat").select_option(category)
         self.page.locator("#newRuleType").select_option(match_type)
@@ -142,7 +152,7 @@ class DashboardPage:
         self.page.locator("#rulesSearch").fill(query)
 
     def add_store_pair(self, raw: str, normalized: str):
-        self.click_tab("manage")
+        self.click_tab("organize")
         self.page.locator("#newPairRaw").fill(raw)
         self.page.locator("#newPairNorm").fill(normalized)
         self.page.locator("#addPairBtn").click()

--- a/tests/e2e/test_dashboard.py
+++ b/tests/e2e/test_dashboard.py
@@ -327,7 +327,9 @@ class TestStorePairs:
     def test_add_store_pair(self, dashboard: DashboardPage):
         uid = _uid()
         dashboard.add_store_pair(f"raw_{uid}", f"norm_{uid}")
-        expect(dashboard.toast).to_contain_text(re.compile(r"normalized|recategorized", re.IGNORECASE))
+        expect(dashboard.toast).to_contain_text(
+            re.compile(r"normalized|recategorized", re.IGNORECASE)
+        )
 
     def test_search_pairs_filters(self, dashboard: DashboardPage):
         uid = _uid()

--- a/tests/e2e/test_dashboard.py
+++ b/tests/e2e/test_dashboard.py
@@ -203,7 +203,7 @@ class TestInlineCategory:
         dashboard.search_transactions("unknown shop xyz")
         expect(dashboard.txn_rows.first).to_be_visible()
         dashboard.inline_set_category(0, "Health")
-        expect(dashboard.toast).to_contain_text("Updated")
+        expect(dashboard.toast).to_contain_text("rule saved")
 
 
 # --- Delete & Restore ---

--- a/tests/e2e/test_dashboard.py
+++ b/tests/e2e/test_dashboard.py
@@ -84,10 +84,26 @@ class TestTabs:
         expect(dashboard.page.locator("#tab-import")).to_be_visible()
         expect(dashboard.page.get_by_test_id("import-zone")).to_be_visible()
 
-    def test_categorize_tab(self, dashboard: DashboardPage):
+    def test_transactions_tab(self, dashboard: DashboardPage):
+        dashboard.click_tab("transactions")
+        expect(dashboard.page.locator("#tab-transactions")).to_be_visible()
+        expect(dashboard.page.get_by_test_id("txn-table")).to_be_visible()
+
+    def test_organize_tab(self, dashboard: DashboardPage):
         dashboard.click_tab("organize")
         expect(dashboard.page.locator("#tab-organize")).to_be_visible()
         expect(dashboard.page.get_by_test_id("recategorize-btn")).to_be_visible()
+        expect(dashboard.page.locator("#pairsSearch")).to_be_visible()
+
+    def test_reimburse_tab(self, dashboard: DashboardPage):
+        dashboard.click_tab("reimburse")
+        expect(dashboard.page.locator("#tab-reimburse")).to_be_visible()
+        expect(dashboard.page.locator("#addReimburserBtn")).to_be_visible()
+
+    def test_trips_tab(self, dashboard: DashboardPage):
+        dashboard.click_tab("trips")
+        expect(dashboard.page.locator("#tab-trips")).to_be_visible()
+        expect(dashboard.page.locator("#tripsBody")).to_be_visible()
 
     def test_budgets_tab(self, dashboard: DashboardPage):
         dashboard.click_tab("budgets")
@@ -105,6 +121,7 @@ class TestTabs:
 
 class TestFiltering:
     def test_search_narrows_results(self, dashboard: DashboardPage):
+        dashboard.go_to_transactions()
         expect(dashboard.txn_rows.first).to_be_visible()
         initial = dashboard.txn_rows.count()
         dashboard.search_transactions("starbucks")
@@ -113,6 +130,7 @@ class TestFiltering:
         assert dashboard.txn_rows.count() > 0
 
     def test_category_filter(self, dashboard: DashboardPage):
+        dashboard.go_to_transactions()
         expect(dashboard.txn_rows.first).to_be_visible()
         initial = dashboard.txn_rows.count()
         dashboard.filter_category("Dining")
@@ -120,6 +138,7 @@ class TestFiltering:
         assert dashboard.txn_rows.count() > 0
 
     def test_date_range_filter(self, dashboard: DashboardPage):
+        dashboard.go_to_transactions()
         expect(dashboard.txn_rows.first).to_be_visible()
         initial = dashboard.txn_rows.count()
         dashboard.filter_date_range("2026-01-01", "2026-01-31")
@@ -308,14 +327,14 @@ class TestStorePairs:
     def test_add_store_pair(self, dashboard: DashboardPage):
         uid = _uid()
         dashboard.add_store_pair(f"raw_{uid}", f"norm_{uid}")
-        expect(dashboard.toast).to_contain_text("Pair added")
+        expect(dashboard.toast).to_contain_text(re.compile(r"normalized|recategorized", re.IGNORECASE))
 
     def test_search_pairs_filters(self, dashboard: DashboardPage):
         uid = _uid()
         dashboard.add_store_pair(f"searchable_{uid}", f"target_{uid}")
         expect(dashboard.toast).to_be_visible()
         dashboard.search_pairs(f"searchable_{uid}")
-        expect(dashboard.page.locator("#pairsCount")).to_contain_text("1/")
+        expect(dashboard.page.locator("#pairsCount")).to_contain_text("1 group")
 
 
 # --- Analytics ---
@@ -359,6 +378,7 @@ class TestAnalytics:
 
 class TestExport:
     def test_export_button_visible(self, dashboard: DashboardPage):
+        dashboard.go_to_transactions()
         expect(dashboard.export_btn).to_be_visible()
         expect(dashboard.export_btn).to_have_text("Export CSV")
 
@@ -368,16 +388,68 @@ class TestExport:
 
 class TestSorting:
     def test_sort_by_amount(self, dashboard: DashboardPage):
+        dashboard.go_to_transactions()
         expect(dashboard.txn_rows.first).to_be_visible()
         dashboard.page.locator("th[data-col='amount']").click()
         expect(dashboard.txn_rows.first).to_be_visible()
 
     def test_sort_by_date(self, dashboard: DashboardPage):
+        dashboard.go_to_transactions()
         expect(dashboard.txn_rows.first).to_be_visible()
         dashboard.page.locator("th[data-col='date']").click()
         expect(dashboard.txn_rows.first).to_be_visible()
 
     def test_sort_by_store(self, dashboard: DashboardPage):
+        dashboard.go_to_transactions()
         expect(dashboard.txn_rows.first).to_be_visible()
         dashboard.page.locator("th[data-col='store']").click()
         expect(dashboard.txn_rows.first).to_be_visible()
+
+
+# --- Reimburse ---
+
+
+class TestReimburse:
+    def test_reimburse_tab_renders(self, dashboard: DashboardPage):
+        dashboard.click_tab("reimburse")
+        expect(dashboard.page.locator("#tab-reimburse")).to_be_visible()
+        expect(dashboard.page.locator("#addReimburserBtn")).to_be_visible()
+        expect(dashboard.page.get_by_test_id("pending-reimb-body")).to_be_attached()
+
+    def test_add_reimburser(self, dashboard: DashboardPage):
+        uid = _uid()
+        dashboard.add_reimburser(f"e2e_reimb_{uid}")
+        expect(dashboard.toast).to_contain_text("Reimburser added")
+
+    def test_reimburser_pairs_form_visible(self, dashboard: DashboardPage):
+        dashboard.click_tab("reimburse")
+        expect(dashboard.page.locator("#addReimbPairBtn")).to_be_visible()
+
+
+# --- Trips ---
+
+
+class TestTrips:
+    def test_trips_tab_renders(self, dashboard: DashboardPage):
+        dashboard.click_tab("trips")
+        expect(dashboard.page.locator("#tab-trips")).to_be_visible()
+        expect(dashboard.page.locator("#tripsBody")).to_be_visible()
+
+    def test_create_trip(self, dashboard: DashboardPage):
+        uid = _uid()
+        dashboard.create_trip(f"E2E Trip {uid}", "2026-01-01", "2026-01-31")
+        expect(dashboard.toast).to_contain_text("Trip created")
+
+    def test_trip_appears_in_table(self, dashboard: DashboardPage):
+        uid = _uid()
+        name = f"TableTrip_{uid}"
+        dashboard.create_trip(name, "2026-02-01", "2026-02-28")
+        expect(dashboard.toast).to_contain_text("Trip created")
+        expect(dashboard.page.locator("#tripsBody")).to_contain_text(name)
+
+    def test_trip_create_form_visible(self, dashboard: DashboardPage):
+        dashboard.click_tab("trips")
+        expect(dashboard.page.locator("#newTripName")).to_be_visible()
+        expect(dashboard.page.locator("#newTripStart")).to_be_visible()
+        expect(dashboard.page.locator("#newTripEnd")).to_be_visible()
+        expect(dashboard.page.locator("#createTripBtn")).to_be_visible()

--- a/tests/e2e/test_dashboard.py
+++ b/tests/e2e/test_dashboard.py
@@ -60,6 +60,7 @@ class TestPageLoad:
         expect(canvas).to_be_visible()
 
     def test_transaction_table_has_rows(self, dashboard: DashboardPage):
+        dashboard.click_tab("transactions")
         expect(dashboard.txn_rows.first).to_be_visible()
         expect(dashboard.page.locator("#txnCount")).to_contain_text("Showing")
 
@@ -84,8 +85,8 @@ class TestTabs:
         expect(dashboard.page.get_by_test_id("import-zone")).to_be_visible()
 
     def test_categorize_tab(self, dashboard: DashboardPage):
-        dashboard.click_tab("categorize")
-        expect(dashboard.page.locator("#tab-categorize")).to_be_visible()
+        dashboard.click_tab("organize")
+        expect(dashboard.page.locator("#tab-organize")).to_be_visible()
         expect(dashboard.page.get_by_test_id("recategorize-btn")).to_be_visible()
 
     def test_budgets_tab(self, dashboard: DashboardPage):
@@ -94,8 +95,8 @@ class TestTabs:
         expect(dashboard.page.locator("#budgetChart")).to_be_visible()
 
     def test_manage_tab(self, dashboard: DashboardPage):
-        dashboard.click_tab("manage")
-        expect(dashboard.page.locator("#tab-manage")).to_be_visible()
+        dashboard.click_tab("organize")
+        expect(dashboard.page.locator("#tab-organize")).to_be_visible()
         expect(dashboard.page.locator("#rulesSearch")).to_be_visible()
 
 
@@ -195,7 +196,7 @@ class TestDeleteRestore:
         expect(dashboard.txn_rows.first).to_be_visible()
         dashboard.delete_row(0)
         expect(dashboard.toast).to_contain_text("deleted")
-        dashboard.click_tab("manage")
+        dashboard.click_tab("organize")
         expect(dashboard.recycle_bin_rows.first).to_be_visible()
 
     def test_restore_from_recycle_bin(self, dashboard: DashboardPage):
@@ -203,7 +204,7 @@ class TestDeleteRestore:
         expect(dashboard.txn_rows.first).to_be_visible()
         dashboard.delete_row(0)
         expect(dashboard.toast).to_contain_text("deleted")
-        dashboard.click_tab("manage")
+        dashboard.click_tab("organize")
         expect(dashboard.recycle_bin_rows.first).to_be_visible()
         count_before = dashboard.recycle_bin_rows.count()
         dashboard.restore_first_deleted()
@@ -250,7 +251,7 @@ class TestCategorize:
         )
 
     def test_uncategorized_section_exists(self, dashboard: DashboardPage):
-        dashboard.click_tab("categorize")
+        dashboard.click_tab("organize")
         section = dashboard.page.locator("#uncategorizedSection")
         expect(section).to_be_visible()
 
@@ -288,14 +289,14 @@ class TestRules:
         expect(dashboard.toast).to_contain_text("Rule added")
 
     def test_search_rules_filters(self, dashboard: DashboardPage):
-        dashboard.click_tab("manage")
+        dashboard.click_tab("organize")
         count_el = dashboard.page.locator("#rulesCount")
         expect(count_el).to_have_text(re.compile(r"\(\d+/\d+\)"))
         dashboard.search_rules("starbucks")
         expect(count_el).to_have_text(re.compile(r"\(\d+/\d+\)"))
 
     def test_rules_count_shows_total(self, dashboard: DashboardPage):
-        dashboard.click_tab("manage")
+        dashboard.click_tab("organize")
         count_el = dashboard.page.locator("#rulesCount")
         expect(count_el).to_have_text(re.compile(r"\(\d+/\d+\)"))
 

--- a/tests/test_smtm.py
+++ b/tests/test_smtm.py
@@ -1087,6 +1087,83 @@ class TestEndToEnd:
         assert result.returncode == 0
         assert "Not found or not linked" in result.stdout
 
+    def test_cli_suggest(self, tmp_path):
+        db_path = tmp_path / "test.db"
+        base = [sys.executable, "-m", "smtm.cli", "--db-path", str(db_path), "--csv-dir", str(FIXTURES)]
+        subprocess.run(base + ["import"], capture_output=True, text=True)
+        result = subprocess.run(base + ["suggest"], capture_output=True, text=True)
+        assert result.returncode == 0
+
+    def test_cli_suggest_apply(self, tmp_path):
+        db_path = tmp_path / "test.db"
+        base = [sys.executable, "-m", "smtm.cli", "--db-path", str(db_path), "--csv-dir", str(FIXTURES)]
+        subprocess.run(base + ["import"], capture_output=True, text=True)
+        result = subprocess.run(base + ["suggest", "--apply"], capture_output=True, text=True)
+        assert result.returncode == 0
+
+    def test_cli_report_text(self, tmp_path):
+        db_path = tmp_path / "test.db"
+        base = [sys.executable, "-m", "smtm.cli", "--db-path", str(db_path), "--csv-dir", str(FIXTURES)]
+        subprocess.run(base + ["import"], capture_output=True, text=True)
+        result = subprocess.run(base + ["report"], capture_output=True, text=True)
+        assert result.returncode == 0
+        assert "TOTAL" in result.stdout or "SUMMARY" in result.stdout
+
+    def test_cli_report_html(self, tmp_path):
+        db_path = tmp_path / "test.db"
+        out = tmp_path / "report.html"
+        base = [sys.executable, "-m", "smtm.cli", "--db-path", str(db_path), "--csv-dir", str(FIXTURES)]
+        subprocess.run(base + ["import"], capture_output=True, text=True)
+        result = subprocess.run(base + ["report", "--html", "--output", str(out)], capture_output=True, text=True)
+        assert result.returncode == 0
+        assert out.exists()
+        assert "<html" in out.read_text().lower()
+
+    def test_cli_budget_set_copy_show(self, tmp_path):
+        db_path = tmp_path / "test.db"
+        base = [sys.executable, "-m", "smtm.cli", "--db-path", str(db_path), "--csv-dir", str(FIXTURES)]
+        subprocess.run(base + ["import"], capture_output=True, text=True)
+        result = subprocess.run(base + ["budget", "set", "2026-01", "Dining=500"], capture_output=True, text=True)
+        assert result.returncode == 0
+        result = subprocess.run(base + ["budget", "copy", "2026-01", "2026-02"], capture_output=True, text=True)
+        assert result.returncode == 0
+        result = subprocess.run(base + ["budget", "show"], capture_output=True, text=True)
+        assert result.returncode == 0
+        assert "Dining" in result.stdout
+        result = subprocess.run(base + ["budget", "show", "2026-01"], capture_output=True, text=True)
+        assert result.returncode == 0
+        assert "Dining" in result.stdout
+
+    def test_cli_history(self, tmp_path):
+        db_path = tmp_path / "test.db"
+        base = [sys.executable, "-m", "smtm.cli", "--db-path", str(db_path), "--csv-dir", str(FIXTURES)]
+        subprocess.run(base + ["import"], capture_output=True, text=True)
+        result = subprocess.run(base + ["history"], capture_output=True, text=True)
+        assert result.returncode == 0
+        assert result.stdout.strip()
+
+    def test_cli_stores_list(self, tmp_path):
+        db_path = tmp_path / "test.db"
+        base = [sys.executable, "-m", "smtm.cli", "--db-path", str(db_path), "--csv-dir", str(FIXTURES)]
+        subprocess.run(base + ["import"], capture_output=True, text=True)
+        result = subprocess.run(base + ["stores", "list"], capture_output=True, text=True)
+        assert result.returncode == 0
+        assert result.stdout.strip()
+
+    def test_cli_stores_discover(self, tmp_path):
+        db_path = tmp_path / "test.db"
+        base = [sys.executable, "-m", "smtm.cli", "--db-path", str(db_path), "--csv-dir", str(FIXTURES)]
+        subprocess.run(base + ["import"], capture_output=True, text=True)
+        result = subprocess.run(base + ["stores", "discover"], capture_output=True, text=True)
+        assert result.returncode == 0
+
+    def test_cli_stores_dupes(self, tmp_path):
+        db_path = tmp_path / "test.db"
+        base = [sys.executable, "-m", "smtm.cli", "--db-path", str(db_path), "--csv-dir", str(FIXTURES)]
+        subprocess.run(base + ["import"], capture_output=True, text=True)
+        result = subprocess.run(base + ["stores", "duplicates"], capture_output=True, text=True)
+        assert result.returncode == 0
+
     def test_import_dedup(self, tmp_path):
         """Importing the same files twice should produce 0 new on second run."""
         db_path = tmp_path / "test.db"

--- a/tests/test_smtm.py
+++ b/tests/test_smtm.py
@@ -1089,21 +1089,47 @@ class TestEndToEnd:
 
     def test_cli_suggest(self, tmp_path):
         db_path = tmp_path / "test.db"
-        base = [sys.executable, "-m", "smtm.cli", "--db-path", str(db_path), "--csv-dir", str(FIXTURES)]
+        base = [
+            sys.executable,
+            "-m",
+            "smtm.cli",
+            "--db-path",
+            str(db_path),
+            "--csv-dir",
+            str(FIXTURES),
+        ]
         subprocess.run(base + ["import"], capture_output=True, text=True)
         result = subprocess.run(base + ["suggest"], capture_output=True, text=True)
         assert result.returncode == 0
 
     def test_cli_suggest_apply(self, tmp_path):
         db_path = tmp_path / "test.db"
-        base = [sys.executable, "-m", "smtm.cli", "--db-path", str(db_path), "--csv-dir", str(FIXTURES)]
+        base = [
+            sys.executable,
+            "-m",
+            "smtm.cli",
+            "--db-path",
+            str(db_path),
+            "--csv-dir",
+            str(FIXTURES),
+        ]
         subprocess.run(base + ["import"], capture_output=True, text=True)
-        result = subprocess.run(base + ["suggest", "--apply"], capture_output=True, text=True)
+        result = subprocess.run(
+            base + ["suggest", "--apply"], capture_output=True, text=True
+        )
         assert result.returncode == 0
 
     def test_cli_report_text(self, tmp_path):
         db_path = tmp_path / "test.db"
-        base = [sys.executable, "-m", "smtm.cli", "--db-path", str(db_path), "--csv-dir", str(FIXTURES)]
+        base = [
+            sys.executable,
+            "-m",
+            "smtm.cli",
+            "--db-path",
+            str(db_path),
+            "--csv-dir",
+            str(FIXTURES),
+        ]
         subprocess.run(base + ["import"], capture_output=True, text=True)
         result = subprocess.run(base + ["report"], capture_output=True, text=True)
         assert result.returncode == 0
@@ -1112,31 +1138,71 @@ class TestEndToEnd:
     def test_cli_report_html(self, tmp_path):
         db_path = tmp_path / "test.db"
         out = tmp_path / "report.html"
-        base = [sys.executable, "-m", "smtm.cli", "--db-path", str(db_path), "--csv-dir", str(FIXTURES)]
+        base = [
+            sys.executable,
+            "-m",
+            "smtm.cli",
+            "--db-path",
+            str(db_path),
+            "--csv-dir",
+            str(FIXTURES),
+        ]
         subprocess.run(base + ["import"], capture_output=True, text=True)
-        result = subprocess.run(base + ["report", "--html", "--output", str(out)], capture_output=True, text=True)
+        result = subprocess.run(
+            base + ["report", "--html", "--output", str(out)],
+            capture_output=True,
+            text=True,
+        )
         assert result.returncode == 0
         assert out.exists()
         assert "<html" in out.read_text().lower()
 
     def test_cli_budget_set_copy_show(self, tmp_path):
         db_path = tmp_path / "test.db"
-        base = [sys.executable, "-m", "smtm.cli", "--db-path", str(db_path), "--csv-dir", str(FIXTURES)]
+        base = [
+            sys.executable,
+            "-m",
+            "smtm.cli",
+            "--db-path",
+            str(db_path),
+            "--csv-dir",
+            str(FIXTURES),
+        ]
         subprocess.run(base + ["import"], capture_output=True, text=True)
-        result = subprocess.run(base + ["budget", "set", "2026-01", "Dining=500"], capture_output=True, text=True)
+        result = subprocess.run(
+            base + ["budget", "set", "2026-01", "Dining=500"],
+            capture_output=True,
+            text=True,
+        )
         assert result.returncode == 0
-        result = subprocess.run(base + ["budget", "copy", "2026-01", "2026-02"], capture_output=True, text=True)
+        result = subprocess.run(
+            base + ["budget", "copy", "2026-01", "2026-02"],
+            capture_output=True,
+            text=True,
+        )
         assert result.returncode == 0
-        result = subprocess.run(base + ["budget", "show"], capture_output=True, text=True)
+        result = subprocess.run(
+            base + ["budget", "show"], capture_output=True, text=True
+        )
         assert result.returncode == 0
         assert "Dining" in result.stdout
-        result = subprocess.run(base + ["budget", "show", "2026-01"], capture_output=True, text=True)
+        result = subprocess.run(
+            base + ["budget", "show", "2026-01"], capture_output=True, text=True
+        )
         assert result.returncode == 0
         assert "Dining" in result.stdout
 
     def test_cli_history(self, tmp_path):
         db_path = tmp_path / "test.db"
-        base = [sys.executable, "-m", "smtm.cli", "--db-path", str(db_path), "--csv-dir", str(FIXTURES)]
+        base = [
+            sys.executable,
+            "-m",
+            "smtm.cli",
+            "--db-path",
+            str(db_path),
+            "--csv-dir",
+            str(FIXTURES),
+        ]
         subprocess.run(base + ["import"], capture_output=True, text=True)
         result = subprocess.run(base + ["history"], capture_output=True, text=True)
         assert result.returncode == 0
@@ -1144,24 +1210,54 @@ class TestEndToEnd:
 
     def test_cli_stores_list(self, tmp_path):
         db_path = tmp_path / "test.db"
-        base = [sys.executable, "-m", "smtm.cli", "--db-path", str(db_path), "--csv-dir", str(FIXTURES)]
+        base = [
+            sys.executable,
+            "-m",
+            "smtm.cli",
+            "--db-path",
+            str(db_path),
+            "--csv-dir",
+            str(FIXTURES),
+        ]
         subprocess.run(base + ["import"], capture_output=True, text=True)
-        result = subprocess.run(base + ["stores", "list"], capture_output=True, text=True)
+        result = subprocess.run(
+            base + ["stores", "list"], capture_output=True, text=True
+        )
         assert result.returncode == 0
         assert result.stdout.strip()
 
     def test_cli_stores_discover(self, tmp_path):
         db_path = tmp_path / "test.db"
-        base = [sys.executable, "-m", "smtm.cli", "--db-path", str(db_path), "--csv-dir", str(FIXTURES)]
+        base = [
+            sys.executable,
+            "-m",
+            "smtm.cli",
+            "--db-path",
+            str(db_path),
+            "--csv-dir",
+            str(FIXTURES),
+        ]
         subprocess.run(base + ["import"], capture_output=True, text=True)
-        result = subprocess.run(base + ["stores", "discover"], capture_output=True, text=True)
+        result = subprocess.run(
+            base + ["stores", "discover"], capture_output=True, text=True
+        )
         assert result.returncode == 0
 
     def test_cli_stores_dupes(self, tmp_path):
         db_path = tmp_path / "test.db"
-        base = [sys.executable, "-m", "smtm.cli", "--db-path", str(db_path), "--csv-dir", str(FIXTURES)]
+        base = [
+            sys.executable,
+            "-m",
+            "smtm.cli",
+            "--db-path",
+            str(db_path),
+            "--csv-dir",
+            str(FIXTURES),
+        ]
         subprocess.run(base + ["import"], capture_output=True, text=True)
-        result = subprocess.run(base + ["stores", "duplicates"], capture_output=True, text=True)
+        result = subprocess.run(
+            base + ["stores", "duplicates"], capture_output=True, text=True
+        )
         assert result.returncode == 0
 
     def test_import_dedup(self, tmp_path):


### PR DESCRIPTION
## Summary

- **Trips tab**: full CRUD, date-range auto-assign, excluded categories per trip, per-transaction solo flag
- **Tab restructure**: Categorize+Manage → Organize; Reimburse split to own tab; Transactions gets its own tab. New order: Overview | Transactions | Organize | Budgets | Reimburse | Trips | Analytics | Import
- **Rules**: inline category edit now saves a rule so future imports self-categorize. New "Normalize rule patterns" button rewrites raw-name rule patterns to their normalized equivalents. Orphaned rules (no matching transactions) cleaned up. Count per rule shown in UI.
- **Store pairs**: table collapsed to 2-col with normalized name directly editable (no duplicate display)
- **Data model**: TRANSFER txn type, deleted_at field, numbered migration system (fixes fresh-DB migration skip bug)
- **Charts**: cap canvas height at 280px to prevent blowup on wide screens
- **CI**: e2e job added to GitHub Actions; CLI tests added (suggest, report, budget)

## Test plan

- [ ] All 126 unit tests pass
- [ ] e2e CI job passes (59 tests)
- [ ] Trips tab: create, auto-assign, edit excluded categories, delete
- [ ] Organize tab: recategorize, store pairs rename, rules show txn counts, normalize button
- [ ] Reimburse tab: add reimburser, discover pairs, pending reimbursements
- [ ] Transactions tab: filter, sort, bulk categorize, inline category edit saves rule, export CSV