### PR TITLE
feat: configurable import filters, inline store rename, needs-attention

### DIFF
--- a/smtm/adapters/base.py
+++ b/smtm/adapters/base.py
@@ -31,7 +31,6 @@ def is_transfer_withdrawal(description: str, sub: str) -> bool:
     vs a real transaction (keep)."""
     sub_lower = sub.lower()
     transfer_subs = [
-        "interac e-transfer",
         "mb-transfer",
         "mb-credit card",
         "pc to",

--- a/smtm/adapters/scotia_debit.py
+++ b/smtm/adapters/scotia_debit.py
@@ -35,10 +35,7 @@ class ScotiaDebitNewAdapter(BaseAdapter):
         return "Balance" in peek_df.columns
 
     def ignorable_patterns(self) -> list[str]:
-        return COMMON_IGNORABLE + [
-            "free interac e-transfer",
-            "interac e-transfer",
-        ]
+        return COMMON_IGNORABLE
 
     def parse(self, path: str | Path) -> list[Transaction]:
         path = Path(path)
@@ -90,10 +87,7 @@ class ScotiaDebitOldAdapter(BaseAdapter):
             return False
 
     def ignorable_patterns(self) -> list[str]:
-        return COMMON_IGNORABLE + [
-            "free interac e-transfer",
-            "interac e-transfer",
-        ]
+        return COMMON_IGNORABLE
 
     def parse(self, path: str | Path) -> list[Transaction]:
         path = Path(path)

--- a/smtm/dashboard.py
+++ b/smtm/dashboard.py
@@ -623,10 +623,7 @@ input[type="checkbox"] { accent-color: #3b82f6; width: 14px; height: 14px; curso
         <div><label>To</label><br><input type="date" id="dateTo" style="width:130px"></div>
         <div><label>Min $</label><br><input type="number" id="minAmount" style="width:80px" step="0.01"></div>
         <div><label>Max $</label><br><input type="number" id="maxAmount" style="width:80px" step="0.01"></div>
-        <div style="margin-left:auto;align-self:flex-end;display:flex;gap:8px">
-            <button class="btn btn-outline" id="needsAttentionBtn" title="Show unlabeled e-transfers that need a store name">Needs Attention</button>
-            <button class="btn btn-outline" id="exportCsvBtn" data-testid="export-csv-btn">Export CSV</button>
-        </div>
+        <div style="margin-left:auto;align-self:flex-end"><button class="btn btn-outline" id="exportCsvBtn" data-testid="export-csv-btn">Export CSV</button></div>
     </div>
     <div id="bulkBar" class="bulk-bar hidden" data-testid="bulk-bar">
         <span><span class="count" id="bulkCount">0</span> selected</span>
@@ -1641,15 +1638,6 @@ const App = {
         input.addEventListener('keydown', e => { if (e.key === 'Enter') input.blur(); if (e.key === 'Escape') { cell.textContent = currentName; input.removeEventListener('blur', save); } });
     },
 
-    _needsAttentionActive: false,
-    toggleNeedsAttention() {
-        this._needsAttentionActive = !this._needsAttentionActive;
-        const btn = document.getElementById('needsAttentionBtn');
-        btn.style.color = this._needsAttentionActive ? '#f59e0b' : '';
-        btn.style.borderColor = this._needsAttentionActive ? '#f59e0b' : '';
-        this.renderTable();
-    },
-
     renderRecycleBin() {
         const body = document.getElementById('recycleBody');
         body.innerHTML = this.data.deleted.map(t => {
@@ -1843,14 +1831,7 @@ const App = {
         const dateFrom = document.getElementById('dateFrom').value;
         const dateTo = document.getElementById('dateTo').value;
 
-        const filterPatterns = (this.data.importFilters || []).map(f => ({pat: f.pattern.toLowerCase(), type: f.match_type}));
         let filtered = this.data.transactions.filter(t => {
-            if (this._needsAttentionActive) {
-                const raw = t.store_raw.toLowerCase();
-                const matchesFilter = filterPatterns.some(f => f.type === 'exact' ? raw === f.pat : raw.includes(f.pat));
-                if (!matchesFilter) return false;
-                if (t.store_normalized && t.store_normalized !== t.store_raw) return false;
-            }
             if (search && !t.store_raw.toLowerCase().includes(search) && !t.store_normalized.toLowerCase().includes(search) && !t.category.toLowerCase().includes(search)) return false;
             if (cat && t.category !== cat) return false;
             if (month && t.month !== month) return false;
@@ -2123,9 +2104,6 @@ document.getElementById('bulkClearBtn').addEventListener('click', () => { App._s
 
 // --- CSV export ---
 document.getElementById('exportCsvBtn').addEventListener('click', () => App.exportCsv());
-
-// --- Needs Attention ---
-document.getElementById('needsAttentionBtn').addEventListener('click', () => App.toggleNeedsAttention());
 
 // --- Import filters ---
 document.getElementById('addFilterBtn').addEventListener('click', () => App.addImportFilter());

--- a/smtm/dashboard.py
+++ b/smtm/dashboard.py
@@ -623,7 +623,10 @@ input[type="checkbox"] { accent-color: #3b82f6; width: 14px; height: 14px; curso
         <div><label>To</label><br><input type="date" id="dateTo" style="width:130px"></div>
         <div><label>Min $</label><br><input type="number" id="minAmount" style="width:80px" step="0.01"></div>
         <div><label>Max $</label><br><input type="number" id="maxAmount" style="width:80px" step="0.01"></div>
-        <div style="margin-left:auto;align-self:flex-end"><button class="btn btn-outline" id="exportCsvBtn" data-testid="export-csv-btn">Export CSV</button></div>
+        <div style="margin-left:auto;align-self:flex-end;display:flex;gap:8px">
+            <button class="btn btn-outline" id="needsAttentionBtn" title="Show unlabeled e-transfers that need a store name">Needs Attention</button>
+            <button class="btn btn-outline" id="exportCsvBtn" data-testid="export-csv-btn">Export CSV</button>
+        </div>
     </div>
     <div id="bulkBar" class="bulk-bar hidden" data-testid="bulk-bar">
         <span><span class="count" id="bulkCount">0</span> selected</span>
@@ -845,6 +848,17 @@ input[type="checkbox"] { accent-color: #3b82f6; width: 14px; height: 14px; curso
         <div id="importResult" style="margin-top:16px"></div>
     </div>
     <div class="section">
+        <h2>Import Filters <span id="filtersCount" style="font-size:12px;color:#94a3b8"></span></h2>
+        <p class="subtitle">Transactions matching these patterns are skipped during import. Remove a filter to start importing that type.</p>
+        <div class="form-row">
+            <input type="text" id="newFilterPattern" placeholder="Pattern (e.g. interac e-transfer)">
+            <select id="newFilterType"><option value="substring">substring</option><option value="exact">exact</option></select>
+            <input type="text" id="newFilterLabel" placeholder="Label (optional)">
+            <button class="btn" id="addFilterBtn">Add Filter</button>
+        </div>
+        <div class="scroll-table" style="max-height:300px"><table><thead><tr><th>Pattern</th><th>Match</th><th>Label</th><th></th></tr></thead><tbody id="filtersBody"></tbody></table></div>
+    </div>
+    <div class="section">
         <h2>Import History</h2>
         <div class="scroll-table"><table><thead><tr><th>Date</th><th>File</th><th>Rows</th><th>New</th></tr></thead><tbody id="historyBody"></tbody></table></div>
     </div>
@@ -889,7 +903,7 @@ const App = {
     _txnTotal: 0,
 
     async init() {
-        const [txns, overview, budgets, rules, pairs, history, uncat, suggest, deleted, reimbursers, pendingReimb, reimburserPairs, stores, trips] = await Promise.all([
+        const [txns, overview, budgets, rules, pairs, history, uncat, suggest, deleted, reimbursers, pendingReimb, reimburserPairs, stores, trips, importFilters] = await Promise.all([
             api(`/api/transactions?offset=0&limit=${this._txnPageSize}`),
             api('/api/overview'),
             api('/api/budgets'),
@@ -899,6 +913,7 @@ const App = {
             api('/api/reimbursers'), api('/api/reimbursements/pending'),
             api('/api/reimburser-pairs'), api('/api/stores'),
             api('/api/trips'),
+            api('/api/import-filters'),
         ]);
         this.data.transactions = txns.transactions || [];
         this._txnTotal = txns.total || this.data.transactions.length;
@@ -919,6 +934,7 @@ const App = {
         this.data.expenseStores = stores.expenses || [];
         this.data.incomeStores = stores.income || [];
         this.data.trips = trips.trips || [];
+        this.data.importFilters = importFilters.filters || [];
         this.renderAll();
         this.populateDataLists();
     },
@@ -958,6 +974,7 @@ const App = {
         this.renderStorePairs();
         this.renderReimbursers();
         this.renderHistory();
+        this.renderImportFilters();
         this.renderRecycleBin();
         this.renderTrips();
         this.renderTripCreateExcludes();
@@ -1566,6 +1583,73 @@ const App = {
         ).join('');
     },
 
+    renderImportFilters() {
+        const filters = this.data.importFilters || [];
+        document.getElementById('filtersCount').textContent = `(${filters.length})`;
+        document.getElementById('filtersBody').innerHTML = filters.map(f =>
+            `<tr>
+                <td><code>${f.pattern}</code></td>
+                <td>${f.match_type}</td>
+                <td style="color:#94a3b8">${f.label || ''}</td>
+                <td><button class="btn btn-sm btn-danger" onclick="App.removeImportFilter(${f.id})">Remove</button></td>
+            </tr>`
+        ).join('') || '<tr><td colspan="4" style="color:#94a3b8;padding:12px">No filters — all transactions imported</td></tr>';
+    },
+
+    async addImportFilter() {
+        const pattern = document.getElementById('newFilterPattern').value.trim();
+        const match_type = document.getElementById('newFilterType').value;
+        const label = document.getElementById('newFilterLabel').value.trim();
+        if (!pattern) return;
+        await apiPost('/api/import-filters', {pattern, match_type, label});
+        document.getElementById('newFilterPattern').value = '';
+        document.getElementById('newFilterLabel').value = '';
+        const data = await api('/api/import-filters');
+        this.data.importFilters = data.filters || [];
+        this.renderImportFilters();
+        toast('Filter added');
+    },
+
+    async removeImportFilter(id) {
+        await api(`/api/import-filters/${id}`, {method:'DELETE'});
+        const data = await api('/api/import-filters');
+        this.data.importFilters = data.filters || [];
+        this.renderImportFilters();
+        toast('Filter removed');
+    },
+
+    startStoreEdit(uuid, cell, currentName) {
+        const input = document.createElement('input');
+        input.value = currentName;
+        input.style.cssText = 'width:100%;background:#0f172a;border:1px solid #3b82f6;color:#f8fafc;padding:2px 6px;border-radius:4px;font-size:13px';
+        cell.innerHTML = '';
+        cell.appendChild(input);
+        input.focus();
+        input.select();
+        const save = async () => {
+            const newName = input.value.trim();
+            if (!newName || newName === currentName) { cell.textContent = currentName; return; }
+            const r = await api(`/api/transactions/${uuid}/store`, {method:'PATCH', headers:{'Content-Type':'application/json'}, body:JSON.stringify({store_normalized: newName})});
+            if (r.ok) {
+                const txn = this.data.transactions.find(t => t.uuid === uuid);
+                if (txn) txn.store_normalized = newName;
+                toast(`Store renamed to "${newName}"`);
+            }
+            cell.textContent = newName;
+        };
+        input.addEventListener('blur', save);
+        input.addEventListener('keydown', e => { if (e.key === 'Enter') input.blur(); if (e.key === 'Escape') { cell.textContent = currentName; input.removeEventListener('blur', save); } });
+    },
+
+    _needsAttentionActive: false,
+    toggleNeedsAttention() {
+        this._needsAttentionActive = !this._needsAttentionActive;
+        const btn = document.getElementById('needsAttentionBtn');
+        btn.style.color = this._needsAttentionActive ? '#f59e0b' : '';
+        btn.style.borderColor = this._needsAttentionActive ? '#f59e0b' : '';
+        this.renderTable();
+    },
+
     renderRecycleBin() {
         const body = document.getElementById('recycleBody');
         body.innerHTML = this.data.deleted.map(t => {
@@ -1759,7 +1843,14 @@ const App = {
         const dateFrom = document.getElementById('dateFrom').value;
         const dateTo = document.getElementById('dateTo').value;
 
+        const filterPatterns = (this.data.importFilters || []).map(f => ({pat: f.pattern.toLowerCase(), type: f.match_type}));
         let filtered = this.data.transactions.filter(t => {
+            if (this._needsAttentionActive) {
+                const raw = t.store_raw.toLowerCase();
+                const matchesFilter = filterPatterns.some(f => f.type === 'exact' ? raw === f.pat : raw.includes(f.pat));
+                if (!matchesFilter) return false;
+                if (t.store_normalized && t.store_normalized !== t.store_raw) return false;
+            }
             if (search && !t.store_raw.toLowerCase().includes(search) && !t.store_normalized.toLowerCase().includes(search) && !t.category.toLowerCase().includes(search)) return false;
             if (cat && t.category !== cat) return false;
             if (month && t.month !== month) return false;
@@ -1813,7 +1904,7 @@ const App = {
             return `<tr${rowBg}>
                 <td><input type="checkbox" data-uuid="${t.uuid}" ${checked} onchange="App.toggleSelect('${t.uuid}', this.checked)"></td>
                 <td>${t.date}</td>
-                <td title="${t.store_raw}">${t.store_normalized}</td>
+                <td title="${t.store_raw}" class="store-cell" onclick="App.startStoreEdit('${t.uuid}', this, '${(t.store_normalized||t.store_raw).replace(/'/g,"\\'")}')" style="cursor:pointer" data-uuid="${t.uuid}">${t.store_normalized}</td>
                 <td>${catBadge(t.category)} <select class="inline-cat-select" onchange="App.inlineCategory('${t.uuid}', '${(t.store_normalized||t.store_raw).replace(/'/g,"\\'")}', this.value)"><option value="">edit</option>${catOpts}</select></td>
                 <td style="text-align:right;font-variant-numeric:tabular-nums">${t.type==='income'?'+':'-'}${amtDisplay}</td>
                 <td>${t.type}</td>
@@ -2032,6 +2123,12 @@ document.getElementById('bulkClearBtn').addEventListener('click', () => { App._s
 
 // --- CSV export ---
 document.getElementById('exportCsvBtn').addEventListener('click', () => App.exportCsv());
+
+// --- Needs Attention ---
+document.getElementById('needsAttentionBtn').addEventListener('click', () => App.toggleNeedsAttention());
+
+// --- Import filters ---
+document.getElementById('addFilterBtn').addEventListener('click', () => App.addImportFilter());
 
 // --- Rules/pairs search ---
 document.getElementById('rulesSearch').addEventListener('input', () => App.renderRules());

--- a/smtm/db.py
+++ b/smtm/db.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 from .models import CategoryDB, Transaction, TxnType
 
-SCHEMA_VERSION = 5
+SCHEMA_VERSION = 6
 
 _MIGRATIONS = [
     # 1: linked reimbursements
@@ -22,6 +22,13 @@ _MIGRATIONS = [
     "ALTER TABLE trip_transactions ADD COLUMN is_solo INTEGER DEFAULT 0",
     # 5: soft-delete timestamp
     "ALTER TABLE transactions ADD COLUMN deleted_at TEXT DEFAULT ''",
+    # 6: configurable import filters
+    """CREATE TABLE IF NOT EXISTS import_filters (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        pattern TEXT UNIQUE NOT NULL,
+        match_type TEXT NOT NULL DEFAULT 'substring',
+        label TEXT NOT NULL DEFAULT ''
+    )""",
 ]
 
 SCHEMA_SQL = """
@@ -100,6 +107,13 @@ CREATE TABLE IF NOT EXISTS import_log (
 
 CREATE INDEX IF NOT EXISTS idx_import_hash ON import_log(file_hash);
 
+CREATE TABLE IF NOT EXISTS import_filters (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    pattern TEXT UNIQUE NOT NULL,
+    match_type TEXT NOT NULL DEFAULT 'substring',
+    label TEXT NOT NULL DEFAULT ''
+);
+
 CREATE TABLE IF NOT EXISTS trips (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     name TEXT NOT NULL,
@@ -162,6 +176,7 @@ class Database:
                     (SCHEMA_VERSION,),
                 )
             self._migrate()
+        self._seed_import_filters()
 
     def _migrate(self):
         row = self.conn.execute("SELECT version FROM schema_version").fetchone()
@@ -175,6 +190,58 @@ class Database:
                         pass  # column already exists — idempotent
                     self.conn.execute("UPDATE schema_version SET version = ?", (i,))
                     ver = i
+
+    # -- Import filters --
+
+    _DEFAULT_IMPORT_FILTERS = [
+        ("mb-credit card/loc pay", "substring", "Credit card payment"),
+        ("mb-transfer", "substring", "Inter-account transfer"),
+        ("pc to", "substring", "Inter-account transfer"),
+        ("pc from", "substring", "Inter-account transfer"),
+        ("mb-cash advance", "substring", "Cash advance"),
+        ("mb - cash advance", "substring", "Cash advance"),
+        ("pc - payment", "substring", "Payment"),
+        ("customer transfer dr.", "substring", "Customer transfer"),
+        ("customer transfer cr.", "substring", "Customer transfer"),
+        ("crd. card bill payment", "substring", "Credit card payment"),
+        ("interac e-transfer", "substring", "E-transfer"),
+        ("free interac e-transfer", "substring", "E-transfer"),
+    ]
+
+    def _seed_import_filters(self):
+        count = self.conn.execute("SELECT COUNT(*) FROM import_filters").fetchone()[0]
+        if count == 0:
+            with self.conn:
+                for pattern, match_type, label in self._DEFAULT_IMPORT_FILTERS:
+                    self.conn.execute(
+                        "INSERT OR IGNORE INTO import_filters (pattern, match_type, label) "
+                        "VALUES (?, ?, ?)",
+                        (pattern, match_type, label),
+                    )
+
+    def get_import_filters(self) -> list[dict]:
+        with self._lock:
+            rows = self.conn.execute(
+                "SELECT id, pattern, match_type, label FROM import_filters ORDER BY id"
+            ).fetchall()
+        return [dict(r) for r in rows]
+
+    def add_import_filter(
+        self, pattern: str, match_type: str = "substring", label: str = ""
+    ) -> int:
+        with self.conn:
+            cur = self.conn.execute(
+                "INSERT INTO import_filters (pattern, match_type, label) VALUES (?, ?, ?)",
+                (pattern, match_type, label),
+            )
+        return cur.lastrowid
+
+    def remove_import_filter(self, filter_id: int) -> bool:
+        with self.conn:
+            cur = self.conn.execute(
+                "DELETE FROM import_filters WHERE id = ?", (filter_id,)
+            )
+        return cur.rowcount > 0
 
     # -- Import log --
 
@@ -299,6 +366,14 @@ class Database:
                 "UPDATE transactions SET txn_type = ? WHERE uuid = ?",
                 (txn_type, uuid),
             )
+
+    def update_store_normalized(self, uuid: str, store_normalized: str) -> bool:
+        with self.conn:
+            cur = self.conn.execute(
+                "UPDATE transactions SET store_normalized = ? WHERE uuid = ?",
+                (store_normalized, uuid),
+            )
+        return cur.rowcount > 0
 
     def recategorize_all(self, category_db: CategoryDB):
         """Re-run categorization on all uncategorized transactions."""

--- a/smtm/importer.py
+++ b/smtm/importer.py
@@ -6,7 +6,20 @@ from pathlib import Path
 from .adapters import detect_and_parse
 from .categorizer import categorize
 from .db import Database
-from .models import CategoryDB
+from .models import CategoryDB, Transaction
+
+
+def _matches_import_filter(txn: Transaction, filters: list[dict]) -> bool:
+    combined = f"{txn.store_raw} | {txn.sub_description}".lower()
+    for f in filters:
+        pat = f["pattern"].lower()
+        if f["match_type"] == "exact":
+            if txn.store_raw.lower() == pat:
+                return True
+        else:
+            if pat in combined:
+                return True
+    return False
 
 
 def import_file(
@@ -32,6 +45,9 @@ def import_file(
         }
 
     txns = detect_and_parse(csv_path)
+    filters = db.get_import_filters()
+    if filters:
+        txns = [t for t in txns if not _matches_import_filter(t, filters)]
     if not txns:
         return {
             "file": csv_path.name,

--- a/smtm/models.py
+++ b/smtm/models.py
@@ -1,9 +1,9 @@
 """Core data models."""
 
+import hashlib
 from dataclasses import dataclass, field
 from datetime import date
 from enum import Enum
-from uuid import uuid4
 
 
 class TxnType(Enum):
@@ -31,7 +31,8 @@ class Transaction:
 
     def __post_init__(self):
         if not self.uuid:
-            self.uuid = str(uuid4())
+            key = f"{self.date}|{self.amount}|{self.store_raw}|{self.sub_description}|{self.source_file}"
+            self.uuid = hashlib.sha256(key.encode()).hexdigest()[:32]
 
     @property
     def month(self) -> str:

--- a/smtm/server.py
+++ b/smtm/server.py
@@ -502,6 +502,8 @@ class Handler(BaseHTTPRequestHandler):
             self._json_response({"pairs": self.db.get_reimburser_pairs()})
         elif path == "/api/reimburser-pairs/discover":
             self._json_response({"discovered": self.db.discover_reimburser_pairs()})
+        elif path == "/api/import-filters":
+            self._json_response({"filters": self.db.get_import_filters()})
         elif path == "/api/trips":
             self._json_response({"trips": self.db.get_trips()})
         elif re.match(r"^/api/trips/(\d+)$", path):
@@ -525,6 +527,16 @@ class Handler(BaseHTTPRequestHandler):
             self._handle_import(preview=False)
         elif path == "/api/import/preview":
             self._handle_import(preview=True)
+        elif path == "/api/import-filters":
+            data = self._read_json_body()
+            pattern = data.get("pattern", "").strip()
+            match_type = data.get("match_type", "substring")
+            label = data.get("label", "")
+            if not pattern:
+                self._error(400, "pattern required")
+                return
+            self.db.add_import_filter(pattern, match_type, label)
+            self._json_response({"ok": True})
         elif path == "/api/rules/normalize":
             normalized = self.db.normalize_rules()
             self._json_response({"ok": True, "normalized": normalized})
@@ -718,7 +730,18 @@ class Handler(BaseHTTPRequestHandler):
         parsed = urlparse(self.path)
         path = parsed.path.rstrip("/") or "/"
 
-        if path.startswith("/api/transactions/") and "/category" in path:
+        if path.startswith("/api/transactions/") and path.endswith("/store"):
+            uuid = path[len("/api/transactions/") : -len("/store")]
+            data = self._read_json_body()
+            store_normalized = data.get("store_normalized", "").strip()
+            if not store_normalized:
+                self._error(400, "store_normalized required")
+                return
+            if self.db.update_store_normalized(uuid, store_normalized):
+                self._json_response({"ok": True})
+            else:
+                self._error(404, "Transaction not found")
+        elif path.startswith("/api/transactions/") and "/category" in path:
             uuid = self._extract_uuid(path, "/api/transactions/")
             if uuid.endswith("/category"):
                 uuid = uuid[:-9]
@@ -747,7 +770,13 @@ class Handler(BaseHTTPRequestHandler):
         parsed = urlparse(self.path)
         path = parsed.path.rstrip("/") or "/"
 
-        if path.startswith("/api/reimbursers/"):
+        if path.startswith("/api/import-filters/"):
+            filter_id = int(path[len("/api/import-filters/") :])
+            if self.db.remove_import_filter(filter_id):
+                self._json_response({"ok": True})
+            else:
+                self._error(404, "Filter not found")
+        elif path.startswith("/api/reimbursers/"):
             pattern = path[len("/api/reimbursers/") :]
             from urllib.parse import unquote
 


### PR DESCRIPTION
## Summary

- **Import filters**: DB-backed table replaces hard-coded ignorable patterns. Seeded with existing common ignorables (credit card payments, inter-account transfers, etc.). Filters applied post-parse in `importer.py`. UI in Import tab to add/remove filters at runtime without touching code.
- **E-transfers imported**: Removed `interac e-transfer` / `free interac e-transfer` from hard-coded adapter filters. They now land in the DB like any other transaction.
- **Inline store rename**: Click any store name in the Transactions table to edit it in-place (`PATCH /api/transactions/:uuid/store`). Saves `store_normalized` without creating a store pair, so `renormalize_all()` won't overwrite it.
- **Needs Attention button**: Filters the transaction table to show only transactions whose `store_raw` matches an import filter pattern AND whose `store_normalized` hasn't been renamed yet — i.e., the e-transfers that need a label.

## Test plan

- [ ] Import a CSV containing e-transfers — verify they appear in the transaction table
- [ ] Click "Needs Attention" — verify only un-renamed e-transfers appear
- [ ] Click store cell → rename → verify name persists after page reload
- [ ] Add a filter in Import tab → re-import same CSV → filtered rows excluded
- [ ] Remove a filter → import again → previously-filtered rows now import